### PR TITLE
controllers/routemonitor: add initial fuzz test

### DIFF
--- a/controllers/routemonitor/routemonitor_controller_supplement_test.go
+++ b/controllers/routemonitor/routemonitor_controller_supplement_test.go
@@ -26,9 +26,14 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	mocks "github.com/openshift/route-monitor-operator/pkg/util/tests/generated/mocks"
+
+	"github.com/google/gofuzz" // fuzz testing
 )
 
 var _ = Describe("Routemonitor", func() {
+	// Add new Fuzzer
+	f := fuzz.New()
+
 	var (
 		routeMonitor          monitoringv1alpha1.RouteMonitor
 		routeMonitorName      string
@@ -64,9 +69,10 @@ var _ = Describe("Routemonitor", func() {
 			}}
 		customError = errors.New("test")
 	)
+	// Start Fuzz testing for values
+	f.Fuzz(&routeMonitorName)
+	f.Fuzz(&routeMonitorNamespace)
 	BeforeEach(func() {
-		routeMonitorName = "fake-name"
-		routeMonitorNamespace = "fake-namespace"
 		routeMonitorRouteSpec = monitoringv1alpha1.RouteMonitorRouteSpec{}
 		routeMonitorReconcilerClient = fake.NewFakeClientWithScheme(scheme)
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/go-logr/logr v0.1.0
 	github.com/golang/mock v1.4.3
+	github.com/google/gofuzz v1.2.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/openshift/api v3.9.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=


### PR DESCRIPTION
Add Fuzz test for routeMonitorName and routeMonitorNamespace
That's user controlled input.
Arguably routeMonitorNamespace is double checking because Openshift should have sanitized this already