### PR TITLE
feat(project): make repo v3 complient

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,7 @@
 domain: openshift.io
 layout: go.kubebuilder.io/v2
 repo: github.com/openshift/route-monitor-operator
+projectName: route-monitor-operator
 resources:
 - group: monitoring
   kind: RouteMonitor


### PR DESCRIPTION
it seems the error https://github.com/operator-framework/operator-sdk/blob/74f5a36af68489d8e3d857f2fedbffacf207474e/internal/cmd/operator-sdk/generate/internal/genutil.go#L163 requires adding this

maybe more operations are required, but I didn't look deeper
