### PR TITLE
fix(makefile): [HACK] seperate go-generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,10 @@ vet:
 	go vet ./...
 
 # Generate code
-generate: controller-gen mockgen
+generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+
+go-generate: mockgen
 	go generate ./...
 
 # Build the docker image


### PR DESCRIPTION
in order for our code to  pass app-interface, we need to remove that generation and keep it in our heads always

this is a VERY ugly fix and I hope it's the last
