### PR TITLE
hack: dockerize build pipeline more and fix permission issue on slave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ gomock_reflect*
 
 # generated file, do not commit
 hack/olm-base-resources
+bundle/

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -14,11 +14,15 @@ docker build -f hack/pipeline.dockerfile -t pipelinebuilder:latest ./hack/
 
 # generate the bundle folder
 #vol=$(generate_mac_mount $(pwd) /root/tmp)
-base_command="docker run --rm --workdir /root/tmp --interactive --volume $(pwd):/root/tmp"
+#base_command="docker run --rm --workdir /root/tmp --interactive --volume $(pwd):/root/tmp"
 
-make bundle KUSTOMIZE="${base_command} --entrypoint kustomize pipelinebuilder:latest" OPERATOR_SDK="${base_command} pipelinebuilder:latest"
-$base_command --entrypoint bash pipelinebuilder:latest chown -R $(id -u) bundle
+docker run --name route-monitor-operator-pipeline pipelinebuilder:latest
 
+#make bundle KUSTOMIZE="${base_command} --entrypoint kustomize pipelinebuilder:latest" OPERATOR_SDK="${base_command} pipelinebuilder:latest"
+#$base_command --entrypoint bash pipelinebuilder:latest chown -R $(id -u) bundle
+
+docker cp route-monitor-operator-pipeline:/pipeline/route-monitor-operator/bundle .
+docker rm route-monitor-operator-pipeline
 GIT_HASH=$(git rev-parse --short=7 HEAD)
 GIT_COMMIT_COUNT=$(git rev-list $(git rev-list --max-parents=0 HEAD)..HEAD --count)
 

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -12,17 +12,14 @@ QUAY_IMAGE="$2"
 # Build an image locally that has all tools we need
 docker build -f hack/pipeline.dockerfile -t pipelinebuilder:latest ./hack/
 
-# generate the bundle folder
-#vol=$(generate_mac_mount $(pwd) /root/tmp)
-#base_command="docker run --rm --workdir /root/tmp --interactive --volume $(pwd):/root/tmp"
-
+# Generate the bundle folder
+# Run the builder container 
 docker run --name route-monitor-operator-pipeline pipelinebuilder:latest
-
-#make bundle KUSTOMIZE="${base_command} --entrypoint kustomize pipelinebuilder:latest" OPERATOR_SDK="${base_command} pipelinebuilder:latest"
-#$base_command --entrypoint bash pipelinebuilder:latest chown -R $(id -u) bundle
-
+# Copy the `bundle` folder to host
 docker cp route-monitor-operator-pipeline:/pipeline/route-monitor-operator/bundle .
+# Clean up after ourselves
 docker rm route-monitor-operator-pipeline
+
 GIT_HASH=$(git rev-parse --short=7 HEAD)
 GIT_COMMIT_COUNT=$(git rev-list $(git rev-list --max-parents=0 HEAD)..HEAD --count)
 

--- a/hack/bundler.sh
+++ b/hack/bundler.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git clone https://github.com/openshift/route-monitor-operator.git
+cd route-monitor-operator
+make bundle
+chmod 777 -R bundle/

--- a/hack/pipeline.dockerfile
+++ b/hack/pipeline.dockerfile
@@ -6,12 +6,25 @@ RUN microdnf install -y git
 # install kustomize
 RUN git clone https://github.com/kubernetes-sigs/kustomize.git
 RUN cd kustomize && \
+      git checkout kustomize/v3.8.8 && \
     cd kustomize && \
     go install .
 RUN ~/go/bin/kustomize version
 
-FROM quay.io/operator-framework/operator-sdk:latest
+FROM quay.io/operator-framework/operator-sdk:v1.2.0
 
+# We need git to clone our repo
+RUN microdnf install -y git
+# Clean up after install
 RUN rm -rf /.cache
+# Copy kustomize binary from builder 
 COPY --from=kustomize-builder /root/go/bin/kustomize /usr/local/bin/kustomize
 
+# Set workdir so we have a known location to copy files from
+RUN mkdir /pipeline
+WORKDIR /pipeline
+# Clone base repo into container
+COPY bundler.sh .
+
+# Make all the things
+ENTRYPOINT ["./bundler.sh"]


### PR DESCRIPTION
# What does this do?
* further dockerize the build pipeline
* fix on slave file permissionss
# How?
Dockerfile has been adjusted and extra script added, so that now all parts of the make command are running inside the container and there is no need anymore to mount the local filesystem.

Further the `bundle` folder we need later in the script, is set to `777` so that the Jenkins user can safely clean up afterwards

This fixes #41