### PR TITLE
hack: remove leftover of base_command

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -71,7 +71,6 @@ PREV_VERSION=$(ls "$BUNDLE_DIR" | sort -t . -k 3 -g | tail -n 1)
     "$GIT_HASH" \
     "$QUAY_IMAGE:$GIT_HASH"
 
-$base_command --entrypoint bash pipelinebuilder:latest chown -R $(id -u) bundle
 
 NEW_VERSION=$(ls "$BUNDLE_DIR" | sort -t . -k 3 -g | tail -n 1)
 


### PR DESCRIPTION
overlooked one occurence of base_command that didn't show up as failure during local testing