### PR TITLE
hack,olm: remove operatorgroup

### DIFF
--- a/config/olm/kustomization.yaml
+++ b/config/olm/kustomization.yaml
@@ -1,5 +1,4 @@
 resources:
 - ../prometheus
 - catalogsource.yaml
-- operatorgroup.yaml
 - subscription.yaml

--- a/config/olm/operatorgroup.yaml
+++ b/config/olm/operatorgroup.yaml
@@ -1,9 +1,0 @@
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: ${REPO_NAME}
-  namespace: ${NAMESPACE}
-spec:
-  targetNamespaces: 
-  - ${NAMESPACE}
-

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -43,14 +43,6 @@ objects:
         selector:
           matchLabels:
             control-plane: controller-manager
-    - apiVersion: operators.coreos.com/v1
-      kind: OperatorGroup
-      metadata:
-        name: ${REPO_NAME}
-        namespace: ${NAMESPACE}
-      spec:
-        targetNamespaces:
-        - ${NAMESPACE}
     - apiVersion: operators.coreos.com/v1alpha1
       kind: CatalogSource
       metadata:


### PR DESCRIPTION
We're sticking to one operatorgroup per namespace.
Removing the additional one.