### PR TITLE
hack: adjust file location after build

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -109,7 +109,7 @@ DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
 cat <<EOF > $DOCKERFILE_REGISTRY
 FROM quay.io/openshift/origin-operator-registry:4.5
 
-COPY $SAAS_OPERATOR_DIR manifests
+COPY $BUNDLE_DIR manifests
 RUN initializer --permissive
 
 CMD ["registry-server", "-t", "/tmp/terminate.log"]


### PR DESCRIPTION
We need our files to be in /registry/manifests and not /registry/manifests/route-monitor-operator