### PR TITLE
Add opm build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Include make files
+include project.mk
+include standard.mk
+
 # Current Operator version
 VERSION_MAJOR=0
 VERSION_MINOR=1

--- a/hack/build-opm-catalog.sh
+++ b/hack/build-opm-catalog.sh
@@ -1,0 +1,380 @@
+#!/bin/bash
+
+set -euo pipefail
+
+## Global vars to modify behaviour of the script
+SET_X=${SET_X:-false}
+[[ "$SET_X" != "false" ]] && set -x
+
+DRY_RUN=${DRY_RUN:-false}
+DELETE_TEMP_DIR=${DELETE_TEMP_DIR:-true}
+NO_LOG=${NO_LOG:-false}
+OLM_BUNDLE_VERSIONS_REPO=${OLM_BUNDLE_VERSIONS_REPO:-gitlab.cee.redhat.com/service/saas-operator-versions.git}
+OLM_BUNDLE_VERSIONS_REPO_BRANCH=${OLM_BUNDLE_VERSIONS_REPO_BRANCH:-master}
+
+# Global vars
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+function log() {
+    local to_log=${1}
+    [[ "$NO_LOG" != "false" ]] && return 0
+    local msg
+    msg="$(date "+%Y-%m-%d %H:%M:%S")"
+    [[ "$DRY_RUN" != "false" ]] && msg="$msg -- DRY-RUN"
+    echo "$msg -- $to_log" 1>&2
+}
+
+function check_required_environment() {
+    local count=0
+    for var in OLM_BUNDLE_IMAGE \
+               OLM_CATALOG_IMAGE \
+               OPERATOR_IMAGE \
+               OPERATOR_IMAGE_TAG \
+               OPERATOR_VERSION \
+               OPERATOR_NAME \
+               CONTAINER_ENGINE \
+               CONTAINER_ENGINE_CONFIG_DIR \
+               CURRENT_COMMIT \
+               OLM_CHANNEL
+    do
+        if [ ! "${!var:-}" ]; then
+          log "$var is not set"
+          count=$((count + 1))
+        fi
+    done
+
+    [[ $count -eq 0 ]] && return 0 || return 1
+}
+
+function setup_temp_dir() {
+    local temp_dir
+    temp_dir=$(mktemp -d --suffix "-$(basename "$0")")
+    [[ "$DELETE_TEMP_DIR" == "true" ]] && trap 'rm -rf $temp_dir' EXIT
+
+    echo "$temp_dir"
+}
+
+function setup_local_executable() {
+    local executable=${1}
+    "$REPO_ROOT"/boilerplate/openshift/golang-osd-operator/ensure.sh "$executable" >&2
+    echo "$REPO_ROOT/.$executable/bin/$executable"
+}
+
+function check_bundle_contents_cmd() {
+    bundle_contents_cmd="$REPO_ROOT/hack/generate-operator-bundle-contents.py"
+    if [[ ! -x "$bundle_contents_cmd" ]]; then
+        log "$bundle_contents_cmd is either missing or non-executable"
+        return 1
+    fi
+}
+
+# Check we are running an opm supported container engine
+function check_opm_supported_container_engine() {
+    local image_builder=${1}
+    if [[ "$image_builder" != "docker" && "$image_builder" != "podman" ]]; then
+        # opm error messages are obscure. Let's make this clear
+        log "image_builder $image_builder is not one of docker or podman"
+        return 1
+    fi
+
+    return 0
+}
+
+# Check we will be able to properly authenticate ourselves against the registry
+function check_authenticated_registry_command() {
+    if [[ ! -f "$CONTAINER_ENGINE_CONFIG_DIR/config.json" ]]; then
+        log "$CONTAINER_ENGINE_CONFIG_DIR/config.json missing"
+        return 1
+    fi
+
+    return 0
+}
+
+function setup_authenticated_registry_command() {
+    echo "$CONTAINER_ENGINE --config=$CONTAINER_ENGINE_CONFIG_DIR"
+}
+
+function clone_olm_bundle_versions_repo() {
+    local saas_root_dir=${1}
+
+    local bundle_versions_repo_url
+    if [[ -n "${APP_SRE_BOT_PUSH_TOKEN:-}" ]]; then
+        log "Using APP_SRE_BOT_PUSH_TOKEN credentials to authenticate"
+        bundle_versions_repo_url="https://app:${APP_SRE_BOT_PUSH_TOKEN}@$OLM_BUNDLE_VERSIONS_REPO"
+    else
+        bundle_versions_repo_url="https://$OLM_BUNDLE_VERSIONS_REPO"
+    fi
+
+    log "Cloning $OLM_BUNDLE_VERSIONS_REPO into $saas_root_dir"
+    git clone --branch "$OLM_BUNDLE_VERSIONS_REPO_BRANCH" "$bundle_versions_repo_url" "$saas_root_dir"
+}
+
+function get_prev_operator_version() {
+    local bundle_versions_file=${1}
+
+    local return_message=""
+
+    # if the line contains SKIP it will not be included
+    local prev_operator_version=""
+    local prev_good_operator_version=""
+    local skip_versions=()
+    if [[ -s "$bundle_versions_file" ]]; then
+        log "$bundle_versions_file exists. We'll use to determine current version"
+
+        prev_operator_version=$(tail -n 1 "$bundle_versions_file" | awk '{print $1}')
+
+        # we traverse the bundle versions file backwards
+        # we cannot use pipes here or we would lose the inner variables changes
+        local version
+        while read -r line; do
+            if [[ "$line" == *SKIP* ]]; then
+                version=$(echo "$line" | awk '{print $1}')
+                skip_versions+=("$version")
+            else
+                prev_good_operator_version="$line"
+                break
+            fi
+        done < <(sort -r -t . -k 3 -g "$bundle_versions_file")
+
+        if [[ -z "$prev_good_operator_version" ]]; then
+            # This means that we have skipped all the available versions. In this case we're going to use the last
+            # SKIP version as the prev_good_operator_version to have something to feed replaces in the CSV
+            log "No unskipped version in $bundle_versions_file. We'll use the last skipped one: ${skip_versions[0]}"
+            prev_good_operator_version="${skip_versions[0]}"
+        fi
+
+        log "Previous operator version is $prev_operator_version"
+        log "Previous good operator version is $prev_good_operator_version"
+        return_message="$prev_operator_version $prev_good_operator_version"
+
+        if [[ ${#skip_versions[@]} -gt 0 ]]; then
+            log "We will be skipping: ${skip_versions[*]}"
+            return_message="$return_message ${skip_versions[*]}"
+        fi
+    else
+        log "No $bundle_versions_file exist or it is empty. This is the first time the operator is built"
+        if [[ ! -d "$(dirname "$bundle_versions_file")" ]]; then
+            log "Operator directory doesn't exist in versions repository. Exiting"
+            exit 1
+        fi
+    fi
+
+    echo "$return_message"
+
+}
+
+function build_opm_bundle() {
+    local bundle_contents_cmd=${1}
+    local opm_local_executable=${2}
+    local image_builder=${3}
+    local prev_good_operator_version=${4}
+    # shellcheck disable=SC2206
+    local skip_versions=(${@:5})
+
+    local bundle_temp_dir
+    bundle_temp_dir=$(mktemp -d -p "$temp_dir" bundle.XXXX)
+    local generate_csv_template_args=""
+    [[ -n "$prev_good_operator_version" ]] && generate_csv_template_args="--replaces $prev_good_operator_version"
+    if [[ ${#skip_versions[@]} -gt 0 ]]; then
+        for version in "${skip_versions[@]}"; do
+            generate_csv_template_args="$generate_csv_template_args --skip $version"
+        done
+    fi
+
+    local manifests_temp_dir
+    manifests_temp_dir=$(mktemp -d -p "$bundle_temp_dir" manifests.XXXX)
+    # shellcheck disable=SC2086
+    $bundle_contents_cmd --name "$OPERATOR_NAME" \
+                         --current-version "$OPERATOR_VERSION" \
+                         --image "$OPERATOR_IMAGE" \
+                         --image-tag "$OPERATOR_IMAGE_TAG" \
+                         --output-dir "$manifests_temp_dir" \
+                         $generate_csv_template_args
+
+    # opm won't get anything locally, so we need to push the bundle even in dry run mode
+    # we will use a different tag to make sure those leftovers are clearly recognized
+    # TODO: remove this tag if we're in dry-run mode in the cleanup trap script
+    [[ "$DRY_RUN" == "false" ]] || bundle_image_current_commit="${bundle_image_current_commit}-dryrun"
+
+    log "Creating bundle image $bundle_image_current_commit"
+    local current_dir="$PWD"
+    cd "$bundle_temp_dir"
+    $opm_local_executable alpha bundle build --directory "$manifests_temp_dir" \
+                                             --channels "$OLM_CHANNEL" \
+                                             --default "$OLM_CHANNEL" \
+                                             --package "$OPERATOR_NAME" \
+                                             --tag "$bundle_image_current_commit" \
+                                             --image-builder "$image_builder" \
+                                             --overwrite \
+                                             1>&2
+    cd "$current_dir"
+
+    echo "$bundle_image_current_commit"
+}
+
+function build_opm_catalog() {
+    local opm_local_executable=${1}
+    local image_builder=${2}
+    local bundle_image_current_commit=${3}
+    local catalog_image_current_commit=${4}
+    local prev_operator_version=${5}
+
+    local from_arg=""
+    if [[ "$prev_operator_version" ]]; then
+        local prev_commit=${prev_operator_version#*-}
+        from_arg="--from-index $OLM_CATALOG_IMAGE:$prev_commit"
+    fi
+
+    log "Creating catalog image $catalog_image_current_commit using opm"
+    # shellcheck disable=SC2086
+    $opm_local_executable index add --bundles "$bundle_image_current_commit" \
+                                    --tag "$catalog_image_current_commit" \
+                                    --build-tool "$image_builder" \
+                                    $from_arg
+}
+
+function check_opm_catalog() {
+    local catalog_image_current_commit=${1}
+    local engine_cmd=${2}
+    local grpcurl_local_executable=${3}
+
+    # Check that catalog works fine
+    log "Checking that catalog we have built returns the correct version $OPERATOR_VERSION"
+
+    local free_port
+    free_port=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+
+    log "Running $catalog_image_current_commit and exposing $free_port"
+    local catalog_container_id
+    catalog_container_id=$($engine_cmd run -d -p "$free_port:50051" "$catalog_image_current_commit")
+
+    log "Getting current version from running catalog"
+    current_version_from_catalog=$(
+        $grpcurl_local_executable -plaintext -d '{"name": "'"$OPERATOR_NAME"'"}' \
+            "localhost:$free_port" api.Registry/GetPackage | \
+                jq -r '.channels[] | select(.name=="'"$OLM_CHANNEL"'") | .csvName' | \
+                sed "s/$OPERATOR_NAME\.//"
+    )
+
+    log "Removing docker container $catalog_container_id"
+    $engine_cmd rm -f "$catalog_container_id"
+
+    if [[ "$current_version_from_catalog" != "v$OPERATOR_VERSION" ]]; then
+        log "Version from catalog $current_version_from_catalog != v$OPERATOR_VERSION"
+        return 1
+    fi
+
+    return 0
+}
+
+function add_current_version_to_bundle_versions_file() {
+    local bundle_versions_file=${1}
+    local saas_root_dir=${2}
+    local prev_operator_version=${3}
+
+    log "Adding the current version $OPERATOR_VERSION to the bundle versions file in $OLM_BUNDLE_VERSIONS_REPO"
+    echo "$OPERATOR_VERSION" >> "$bundle_versions_file"
+
+    local current_directory="$PWD"
+
+    cd "$saas_root_dir/$OPERATOR_NAME"
+    git add .
+    message="add version $OPERATOR_VERSION"
+    [[ "$prev_operator_version" ]] && message="$message
+
+    replaces $prev_operator_version"
+
+    git commit -m "$message"
+
+    cd "$current_directory"
+}
+
+function main() {
+    log "Building $OPERATOR_NAME version $OPERATOR_VERSION"
+
+    check_required_environment || return 1
+    check_bundle_contents_cmd || return 1
+    check_authenticated_registry_command || return 1
+
+    local temp_dir
+    local opm_local_executable
+    local grpcurl_local_executable
+    local engine_cmd
+    local image_builder
+    temp_dir=$(setup_temp_dir)
+    opm_local_executable=$(setup_local_executable opm)
+    grpcurl_local_executable=$(setup_local_executable grpcurl)
+    engine_cmd=$(setup_authenticated_registry_command)
+    image_builder=$(basename "$CONTAINER_ENGINE")
+
+    check_opm_supported_container_engine "$image_builder" || return 1
+
+    local saas_root_dir="$temp_dir/saas-operator-versions"
+    clone_olm_bundle_versions_repo "$saas_root_dir"
+
+    local bundle_versions_file="$saas_root_dir/$OPERATOR_NAME/${OPERATOR_NAME}-versions.txt"
+    local versions
+    # shellcheck disable=SC2207
+    versions=($(get_prev_operator_version "$bundle_versions_file"))
+    local prev_operator_version="${versions[0]}"
+    local prev_good_operator_version="${versions[1]}"
+    local skip_versions=("${versions[@]:2}")
+
+    if [[ "$OPERATOR_VERSION" == "$prev_operator_version" ]]; then
+        log "stopping script as $OPERATOR_VERSION version was already built, so no need to rebuild it"
+        return 0
+    fi
+
+    local bundle_image_current_commit="$OLM_BUNDLE_IMAGE:$CURRENT_COMMIT"
+    local bundle_image_latest="$OLM_BUNDLE_IMAGE:latest"
+    local catalog_image_current_commit="$OLM_CATALOG_IMAGE:$CURRENT_COMMIT"
+    local catalog_image_latest="$OLM_CATALOG_IMAGE:latest"
+
+    bundle_image_current_commit=$(build_opm_bundle "$bundle_contents_cmd" \
+                                                   "$opm_local_executable" \
+                                                   "$image_builder" \
+                                                   "$prev_good_operator_version" \
+                                                   "${skip_versions[*]:-}")
+
+    log "Pushing bundle image $bundle_image_current_commit"
+    $engine_cmd push "$bundle_image_current_commit"
+
+    # Make sure this is run after pushing the image
+    log "Validating bundle $bundle_image_current_commit"
+    $opm_local_executable alpha bundle validate --tag "$bundle_image_current_commit" \
+                                                --image-builder "$image_builder"
+
+    log "Tagging bundle image $bundle_image_current_commit as $bundle_image_latest"
+    $engine_cmd tag "$bundle_image_current_commit" "$bundle_image_latest"
+
+    build_opm_catalog "$opm_local_executable" \
+                      "$image_builder" \
+                      "$bundle_image_current_commit" \
+                      "$catalog_image_current_commit" \
+                      "$prev_operator_version"
+
+    check_opm_catalog "$catalog_image_current_commit" "$engine_cmd" "$grpcurl_local_executable" || return 1
+
+    log "Tagging catalog image $catalog_image_current_commit as $catalog_image_latest"
+    $engine_cmd tag "$catalog_image_current_commit" "$catalog_image_latest"
+
+    add_current_version_to_bundle_versions_file "$bundle_versions_file" \
+                                                "$saas_root_dir" \
+                                                "$prev_operator_version"
+
+    log "Pushing catalog image $catalog_image_current_commit"
+    [[ "$DRY_RUN" == "false" ]] && $engine_cmd push "$catalog_image_current_commit"
+
+    log "Pushing bundle image $catalog_image_latest"
+    [[ "$DRY_RUN" == "false" ]] && $engine_cmd push "$catalog_image_latest"
+
+    log "Pushing bundle image $bundle_image_latest"
+    [[ "$DRY_RUN" == "false" ]] && $engine_cmd push "$bundle_image_latest"
+
+    return 0
+}
+
+# Main
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main || exit 1
+fi

--- a/hack/build-opm-catalog.sh
+++ b/hack/build-opm-catalog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 set -euo pipefail
 
@@ -6,7 +6,7 @@ set -euo pipefail
 SET_X=${SET_X:-false}
 [[ "$SET_X" != "false" ]] && set -x
 
-DRY_RUN=${DRY_RUN:-false}
+DRY_RUN=${DRY_RUN:-true}
 DELETE_TEMP_DIR=${DELETE_TEMP_DIR:-true}
 NO_LOG=${NO_LOG:-false}
 OLM_BUNDLE_VERSIONS_REPO=${OLM_BUNDLE_VERSIONS_REPO:-gitlab.cee.redhat.com/service/saas-operator-versions.git}
@@ -312,7 +312,7 @@ function main() {
     local saas_root_dir="$temp_dir/saas-operator-versions"
     clone_olm_bundle_versions_repo "$saas_root_dir"
 
-    local bundle_versions_file="$saas_root_dir/$OPERATOR_NAME/${OPERATOR_NAME}-versions.txt"
+    local bundle_versions_file="/tmp/saas-operator-versions/$OPERATOR_NAME/${OPERATOR_NAME}-versions.txt"
     local versions
     # shellcheck disable=SC2207
     versions=($(get_prev_operator_version "$bundle_versions_file"))
@@ -337,7 +337,7 @@ function main() {
                                                    "${skip_versions[*]:-}")
 
     log "Pushing bundle image $bundle_image_current_commit"
-    $engine_cmd push "$bundle_image_current_commit"
+    [[ "$DRY_RUN" == "false" ]] && $engine_cmd push "$bundle_image_current_commit"
 
     # Make sure this is run after pushing the image
     log "Validating bundle $bundle_image_current_commit"

--- a/hack/build-opm-catalog.sh
+++ b/hack/build-opm-catalog.sh
@@ -107,6 +107,10 @@ function clone_olm_bundle_versions_repo() {
 
     log "Cloning $OLM_BUNDLE_VERSIONS_REPO into $saas_root_dir"
     git clone --branch "$OLM_BUNDLE_VERSIONS_REPO_BRANCH" "$bundle_versions_repo_url" "$saas_root_dir"
+    if [ $? != 0 ]; then
+        log "Failed to clone $OLM_BUNDLE_VERSIONS_REPO"
+        exit 1
+    fi
 }
 
 function get_prev_operator_version() {
@@ -312,7 +316,7 @@ function main() {
     local saas_root_dir="$temp_dir/saas-operator-versions"
     clone_olm_bundle_versions_repo "$saas_root_dir"
 
-    local bundle_versions_file="/tmp/saas-operator-versions/$OPERATOR_NAME/${OPERATOR_NAME}-versions.txt"
+    local bundle_versions_file="$saas_root_dir/$OPERATOR_NAME/${OPERATOR_NAME}-versions.txt"
     local versions
     # shellcheck disable=SC2207
     versions=($(get_prev_operator_version "$bundle_versions_file"))

--- a/hack/generate-operator-bundle-contents.py
+++ b/hack/generate-operator-bundle-contents.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# vim: ts=4:sw=4:cc=99
+
+import datetime
+import os
+import sys
+import yaml
+import pathlib
+import argparse
+
+parser = argparse.ArgumentParser(add_help=False)
+required = parser.add_argument_group('required arguments')
+
+required.add_argument('-n', '--name', help='operator name', type=str, required=True)
+required.add_argument('-c', '--current-version', help='operator version', type=str, required=True)
+required.add_argument('-i', '--image', help='operator image', type=str, required=True)
+required.add_argument('-t', '--image-tag', help='operator image tag', type=str, required=True)
+required.add_argument('-o', '--output-dir', help='output directory', type=str, required=True)
+
+optional = parser.add_argument_group('optional arguments')
+optional.add_argument( '-h', '--help', action='help', default=argparse.SUPPRESS,
+    help='show this help message and exit')
+optional.add_argument('-r', '--replaces', help='Replaces version', type=str)
+optional.add_argument('-s','--skip', action='append',
+        help='Skips version (can be specified multiple times)')
+
+args = parser.parse_args()
+
+root = pathlib.Path(__file__).parent.absolute() / '..'
+manifest_dir = root / 'deploy/openshift'
+csv_template_dir = root / 'deploy/bundle/template'
+
+with open(csv_template_dir / f'{args.name}.clusterserviceversion.yaml',
+        'r') as stream:
+    csv = yaml.safe_load(stream)
+
+csv['spec']['install']['spec']['clusterPermissions'] = []
+with open(manifest_dir / 'cluster-role.yaml', 'r') as stream:
+    operator_role = yaml.safe_load(stream)
+    csv['spec']['install']['spec']['clusterPermissions'].append(
+        {
+            'rules': operator_role['rules'],
+            'serviceAccountName': args.name,
+        })
+
+csv['spec']['install']['spec']['permissions'] = []
+with open(manifest_dir / 'role.yaml', 'r') as stream:
+    operator_role = yaml.safe_load(stream)
+    csv['spec']['install']['spec']['permissions'].append(
+        {
+            'rules': operator_role['rules'],
+            'serviceAccountName': args.name,
+        })
+
+with open(manifest_dir / 'operator.yaml', 'r') as stream:
+    operator_components = []
+    operator = yaml.safe_load_all(stream)
+    for doc in operator:
+        operator_components.append(doc)
+    # There is only one yaml document in the operator deployment
+    operator_deployment = operator_components[0]
+    csv['spec']['install']['spec']['deployments'][0]['spec'] = \
+        operator_deployment['spec']
+
+csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = \
+    csv['metadata']['annotations']['containerImage'] = f'{args.image}:{args.image_tag}'
+csv['metadata']['name'] = f'{args.name}.v{args.current_version}'
+csv['spec']['version'] = args.current_version
+csv['spec']['links'][1]['url'] = f'https://{args.image}:{args.image_tag}'
+
+if args.replaces:
+    csv['spec']['replaces'] = f'{args.name}.v{args.replaces}'
+
+if args.skip:
+    csv['metadata']['annotations']['olm.skipRange'] = ' || '.join(
+        sorted(args.skip, key=lambda v: int(v.split('.')[2].split('-')[0])))
+
+now = datetime.datetime.now()
+csv['metadata']['annotations']['createdAt'] = \
+    now.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+csv_filename = pathlib.Path(args.output_dir) / \
+    f'{args.name}.v{args.current_version}.clusterserviceversion.yaml'
+with open(csv_filename, 'w') as output_file:
+    yaml.dump(csv, output_file, default_flow_style=False)

--- a/hack/test_local_build.sh
+++ b/hack/test_local_build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+OLM_BUNDLE_IMAGE="quay.io/jamesh/route-monitor-operator-bundle" \
+OLM_CATALOG_IMAGE="quay.io/jamesh/route-monitor-operator-catalog" \
+CONTAINER_ENGINE="/usr/bin/podman" \
+CONTAINER_ENGINE_CONFIG_DIR="$HOME/.docker" \
+CURRENT_COMMIT="0492316" \
+OPERATOR_VERSION="0.1.134-0492316" \
+OPERATOR_NAME="route-monitor-operator" \
+OPERATOR_IMAGE="quay.io/jamesh/route-monitor-operator" \
+OPERATOR_IMAGE_TAG="v0.1.134-0492316" \
+OLM_CHANNEL="alpha" \
+./hack/build-opm-catalog.sh

--- a/project.mk
+++ b/project.mk
@@ -1,0 +1,10 @@
+# Project specific values
+OPERATOR_NAME?=$(shell sed -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' config/config.go)
+OPERATOR_NAMESPACE?=$(shell sed -n 's/.*OperatorNamespace .*"\([^"]*\)".*/\1/p' config/config.go)
+
+IMAGE_REGISTRY?=quay.io
+IMAGE_REPOSITORY?=$(USER)
+IMAGE_NAME?=$(OPERATOR_NAME)
+
+VERSION_MAJOR?=0
+VERSION_MINOR?=1

--- a/project.mk
+++ b/project.mk
@@ -1,6 +1,6 @@
 # Project specific values
-OPERATOR_NAME?=$(shell sed -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' config/config.go)
-OPERATOR_NAMESPACE?=$(shell sed -n 's/.*OperatorNamespace .*"\([^"]*\)".*/\1/p' config/config.go)
+OPERATOR_NAME?=$(shell sed -n 's/^projectName:\ \(.*\)/\1/p' PROJECT)
+OPERATOR_NAMESPACE?=openshift-monitoring
 
 IMAGE_REGISTRY?=quay.io
 IMAGE_REPOSITORY?=$(USER)

--- a/standard.mk
+++ b/standard.mk
@@ -1,0 +1,210 @@
+# Validate variables in project.mk exist
+ifndef IMAGE_REGISTRY
+$(error IMAGE_REGISTRY is not set; check project.mk file)
+endif
+ifndef IMAGE_REPOSITORY
+$(error IMAGE_REPOSITORY is not set; check project.mk file)
+endif
+ifndef IMAGE_NAME
+$(error IMAGE_NAME is not set; check project.mk file)
+endif
+ifndef VERSION_MAJOR
+$(error VERSION_MAJOR is not set; check project.mk file)
+endif
+ifndef VERSION_MINOR
+$(error VERSION_MINOR is not set; check project.mk file)
+endif
+
+# Accommodate docker or podman
+CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+
+# Generate version and tag information from inputs
+COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
+CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
+OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
+
+OPERATOR_IMAGE=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
+OPERATOR_IMAGE_TAG=v$(OPERATOR_VERSION)
+IMG?=$(OPERATOR_IMAGE):$(OPERATOR_IMAGE_TAG)
+OPERATOR_IMAGE_URI=${IMG}
+OPERATOR_IMAGE_URI_LATEST=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):latest
+OPERATOR_DOCKERFILE ?=build/Dockerfile
+
+OLM_BUNDLE_IMAGE = $(OPERATOR_IMAGE)-bundle
+OLM_CATALOG_IMAGE = $(OPERATOR_IMAGE)-catalog
+OLM_CHANNEL ?= alpha
+
+REGISTRY_USER ?=
+REGISTRY_TOKEN ?=
+CONTAINER_ENGINE_CONFIG_DIR = .docker
+
+BINFILE=build/_output/bin/$(OPERATOR_NAME)
+MAINPACKAGE=./cmd/manager
+
+GOOS?=$(shell go env GOOS)
+GOARCH?=$(shell go env GOARCH)
+
+# Consumers may override GOFLAGS_MOD e.g. to use `-mod=vendor`
+unexport GOFLAGS
+GOFLAGS_MOD ?=
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD}
+
+GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
+
+# GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
+# Relevant issue - https://github.com/golangci/golangci-lint/issues/734
+GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
+
+GOLANGCI_OPTIONAL_CONFIG ?=
+
+TESTTARGETS := $(shell ${GOENV} go list -e ./... | egrep -v "/(vendor)/")
+# ex, -v
+TESTOPTS :=
+
+ALLOW_DIRTY_CHECKOUT?=false
+
+# TODO: Figure out how to discover this dynamically
+CONVENTION_DIR := boilerplate/openshift/golang-osd-operator
+
+# Set the default goal in a way that works for older & newer versions of `make`:
+# Older versions (<=3.8.0) will pay attention to the `default` target.
+# Newer versions pay attention to .DEFAULT_GOAL, where uunsetting it makes the next defined target the default:
+# https://www.gnu.org/software/make/manual/make.html#index-_002eDEFAULT_005fGOAL-_0028define-default-goal_0029
+.DEFAULT_GOAL :=
+.PHONY: default
+default: go-check go-test go-build
+
+.PHONY: clean
+clean:
+	rm -rf ./build/_output
+
+.PHONY: isclean
+isclean:
+	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)
+
+.PHONY: docker-build
+docker-build: isclean
+	${CONTAINER_ENGINE} build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
+	${CONTAINER_ENGINE} tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
+
+.PHONY: docker-push
+docker-push: docker-login docker-build
+	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${OPERATOR_IMAGE_URI}
+	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${OPERATOR_IMAGE_URI_LATEST}
+
+.PHONY: push
+push: docker-push
+
+.PHONY: docker-login
+docker-login:
+	@test "${REGISTRY_USER}" != "" && test "${REGISTRY_TOKEN}" != "" || (echo "REGISTRY_USER and REGISTRY_TOKEN must be defined" && exit 1)
+	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
+	@${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
+
+.PHONY: go-check
+go-check: ## Golang linting and other static analysis
+	${CONVENTION_DIR}/ensure.sh golangci-lint
+	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
+	test "${GOLANGCI_OPTIONAL_CONFIG}" = "" || test ! -e "${GOLANGCI_OPTIONAL_CONFIG}" || GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE}" golangci-lint run -c "${GOLANGCI_OPTIONAL_CONFIG}" ./...
+
+.PHONY: go-generate
+go-generate:
+	${GOENV} go generate $(TESTTARGETS)
+	# Don't forget to commit generated files
+
+.PHONY: op-generate
+op-generate:
+	${CONVENTION_DIR}/operator-sdk-generate.sh
+	# HACK: Due to an OLM bug in 3.11, we need to remove the
+	# spec.validation.openAPIV3Schema.type from CRDs. Remove once
+	# 3.11 is no longer supported.
+	find deploy/ -name '*_crd.yaml' | xargs -n1 -I{} yq d -i {} spec.validation.openAPIV3Schema.type
+	# Don't forget to commit generated files
+
+.PHONY: generate
+generate: op-generate go-generate
+
+.PHONY: go-build
+go-build: ## Build binary
+	# Force GOOS=linux as we may want to build containers in other *nix-like systems (ie darwin).
+	# This is temporary until a better container build method is developed
+	${GOENV} GOOS=linux go build ${GOBUILDFLAGS} -o ${BINFILE} ${MAINPACKAGE}
+
+.PHONY: go-test
+go-test:
+	${GOENV} go test $(TESTOPTS) $(TESTTARGETS)
+
+.PHONY: python-venv
+python-venv:
+	${CONVENTION_DIR}/ensure.sh venv ${CONVENTION_DIR}/py-requirements.txt
+	$(eval PYTHON := .venv/bin/python3)
+
+.PHONY: generate-check
+generate-check:
+	@$(MAKE) -s isclean --no-print-directory
+	@$(MAKE) -s generate --no-print-directory
+	@$(MAKE) -s isclean --no-print-directory || (echo 'Files after generation are different than committed ones. Please commit updated and unaltered generated files' >&2 && exit 1)
+	@echo "All generated files are up-to-date and unaltered"
+
+.PHONY: yaml-validate
+yaml-validate: python-venv
+	${PYTHON} ${CONVENTION_DIR}/validate-yaml.py $(shell git ls-files | egrep -v '^(vendor|boilerplate)/' | egrep '.*\.ya?ml')
+
+.PHONY: olm-deploy-yaml-validate
+olm-deploy-yaml-validate: python-venv
+	${PYTHON} ${CONVENTION_DIR}/validate-yaml.py $(shell git ls-files 'deploy/*.yaml' 'deploy/*.yml')
+
+.PHONY: prow-config
+prow-config:
+	${CONVENTION_DIR}/prow-config ${RELEASE_CLONE}
+
+.PHONY: codecov-secret-mapping
+codecov-secret-mapping:
+	${CONVENTION_DIR}/codecov-secret-mapping ${RELEASE_CLONE}
+
+######################
+# Targets used by prow
+######################
+
+# validate: Ensure code generation has not been forgotten; and ensure
+# generated and boilerplate code has not been modified.
+.PHONY: validate
+validate: boilerplate-freeze-check generate-check
+
+# lint: Perform static analysis.
+.PHONY: lint
+lint: olm-deploy-yaml-validate go-check
+
+# test: "Local" unit and functional testing.
+.PHONY: test
+test: go-test
+
+# coverage: Code coverage analysis and reporting.
+.PHONY: coverage
+coverage:
+	${CONVENTION_DIR}/codecov.sh
+
+#########################
+# Targets used by app-sre
+#########################
+
+# build-push: Construct, tag, and push the official operator and
+# registry container images.
+# TODO: Boilerplate this script.
+.PHONY: build-push
+build-push:
+	hack/app_sre_build_deploy.sh
+
+.PHONY: opm-build-push
+opm-build-push: docker-push
+	OLM_BUNDLE_IMAGE="${OLM_BUNDLE_IMAGE}" \
+	OLM_CATALOG_IMAGE="${OLM_CATALOG_IMAGE}" \
+	CONTAINER_ENGINE="${CONTAINER_ENGINE}" \
+	CONTAINER_ENGINE_CONFIG_DIR="${CONTAINER_ENGINE_CONFIG_DIR}" \
+	CURRENT_COMMIT="${CURRENT_COMMIT}" \
+	OPERATOR_VERSION="${OPERATOR_VERSION}" \
+	OPERATOR_NAME="${OPERATOR_NAME}" \
+	OPERATOR_IMAGE="${OPERATOR_IMAGE}" \
+	OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG}" \
+	OLM_CHANNEL="${OLM_CHANNEL}" \
+	${CONVENTION_DIR}/build-opm-catalog.sh

--- a/standard.mk
+++ b/standard.mk
@@ -36,9 +36,8 @@ OLM_CHANNEL ?= alpha
 
 REGISTRY_USER ?=
 REGISTRY_TOKEN ?=
-CONTAINER_ENGINE_CONFIG_DIR = .docker
+CONTAINER_ENGINE_CONFIG_DIR = /home/jamesh/.docker
 
-BINFILE=build/_output/bin/$(OPERATOR_NAME)
 MAINPACKAGE=./cmd/manager
 
 GOOS?=$(shell go env GOOS)
@@ -65,18 +64,6 @@ ALLOW_DIRTY_CHECKOUT?=false
 
 # TODO: Figure out how to discover this dynamically
 CONVENTION_DIR := boilerplate/openshift/golang-osd-operator
-
-# Set the default goal in a way that works for older & newer versions of `make`:
-# Older versions (<=3.8.0) will pay attention to the `default` target.
-# Newer versions pay attention to .DEFAULT_GOAL, where uunsetting it makes the next defined target the default:
-# https://www.gnu.org/software/make/manual/make.html#index-_002eDEFAULT_005fGOAL-_0028define-default-goal_0029
-.DEFAULT_GOAL :=
-.PHONY: default
-default: go-check go-test go-build
-
-.PHONY: clean
-clean:
-	rm -rf ./build/_output
 
 .PHONY: isclean
 isclean:
@@ -123,12 +110,6 @@ op-generate:
 
 .PHONY: generate
 generate: op-generate go-generate
-
-.PHONY: go-build
-go-build: ## Build binary
-	# Force GOOS=linux as we may want to build containers in other *nix-like systems (ie darwin).
-	# This is temporary until a better container build method is developed
-	${GOENV} GOOS=linux go build ${GOBUILDFLAGS} -o ${BINFILE} ${MAINPACKAGE}
 
 .PHONY: go-test
 go-test:
@@ -196,7 +177,8 @@ build-push:
 	hack/app_sre_build_deploy.sh
 
 .PHONY: opm-build-push
-opm-build-push: docker-push
+#opm-build-push: docker-push
+opm-build-push:
 	OLM_BUNDLE_IMAGE="${OLM_BUNDLE_IMAGE}" \
 	OLM_CATALOG_IMAGE="${OLM_CATALOG_IMAGE}" \
 	CONTAINER_ENGINE="${CONTAINER_ENGINE}" \
@@ -207,4 +189,4 @@ opm-build-push: docker-push
 	OPERATOR_IMAGE="${OPERATOR_IMAGE}" \
 	OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG}" \
 	OLM_CHANNEL="${OLM_CHANNEL}" \
-	${CONVENTION_DIR}/build-opm-catalog.sh
+	hack/build-opm-catalog.sh


### PR DESCRIPTION
I've lift and shifted boilerplate code for the OPM build process. This isn't 100% working yet and is still a work in process.

There is a local file test_local_build.sh that can be invoked for testing `./hack/test_local_build.sh`

The route-monitor-operator has been added to the saas versions repository `https://gitlab.cee.redhat.com/service/saas-operator-versions/-/tree/master/route-monitor-operator` however there is no version file yet for this operator. We should be able to add a bogus version with SKIP. 

Building this operator with the legacy catalog packagemanifests just means all this work has to be repeated, the build helpers included with the SDK v1 don't build OLM bundles compatible with the packagemanifest.

There shouldn't be much more to make this complete, @rporres should be able to help here if I'm not around. 