### PR TITLE
fix(template): make deployment be in a different namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,14 @@ REPO_NAME?=$(shell basename $$((git config --get-regex remote\.*\.url 2>/dev/nul
 
 SELECTOR_SYNC_SET_DESTINATION?=${GIT_ROOT}/hack/olm-registry/olm-artifacts-template.yaml
 
-ADD_KUSTOMIZE_DATA=mkdir ${YAML_DIRECTORY} || ${KUSTOMIZE} build config/olm/ > ${YAML_DIRECTORY}/00_olm-resources_generated.yaml
+add-kustomize-data: kustomize
+	    rm -rf $(YAML_DIRECTORY)
+	    mkdir $(YAML_DIRECTORY)
+	    $(KUSTOMIZE) build config/olm/ > $(YAML_DIRECTORY)/00_olm-resources_generated.yaml
+
 GEN_SYNCSET=hack/generate_template.py --template-dir ${SELECTOR_SYNC_SET_TEMPLATE_DIR} --yaml-directory ${YAML_DIRECTORY} --destination ${SELECTOR_SYNC_SET_DESTINATION} --repo-name ${REPO_NAME}
 .PHONY: generate-syncset
-generate-syncset: kustomize
-	${ADD_KUSTOMIZE_DATA}; \
+generate-syncset: kustomize add-kustomize-data
 	if [ "${IN_CONTAINER}" == "true" ]; then \
 		$(CONTAINER_ENGINE) run --rm -v $$(pwd -P):$$(pwd -P) quay.io/bitnami/python:2.7.18 /bin/sh -c "cd $$(pwd); pip install oyaml; $$(pwd)/${GEN_SYNCSET}"; \
 	else \

--- a/config/olm/catalogsource.yaml
+++ b/config/olm/catalogsource.yaml
@@ -5,7 +5,6 @@ metadata:
     opsrc-datastore: 'true'
     opsrc-provider: redhat
   name: ${REPO_NAME}-registry
-  namespace: ${NAMESPACE}
 spec:
   image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
   affinity:

--- a/config/olm/kustomization.yaml
+++ b/config/olm/kustomization.yaml
@@ -1,4 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# this variable is used in hack/generate_template.py to override the namespace
+namespace: ${NAMESPACE}
 resources:
 - ../prometheus
 - catalogsource.yaml
+- namespace.yaml
+- operatorgroup.yaml
 - subscription.yaml

--- a/config/olm/namespace.yaml
+++ b/config/olm/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}
+  labels:
+    openshift.io/cluster-monitoring: 'true'

--- a/config/olm/operatorgroup.yaml
+++ b/config/olm/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: route-monitor-operator
+spec: {}

--- a/config/olm/subscription.yaml
+++ b/config/olm/subscription.yaml
@@ -2,7 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: ${REPO_NAME}
-  namespace: ${NAMESPACE}
 spec:
   channel: ${CHANNEL}
   name: ${REPO_NAME}

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -6,7 +6,7 @@ parameters:
 - name: IMAGE_TAG
   required: true
 - name: NAMESPACE
-  value: openshift-monitoring
+  value: openshift-route-monitor-operator
 - name: REGISTRY_IMG
   required: true
 - name: REPO_NAME

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -29,13 +29,19 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        labels:
+          openshift.io/cluster-monitoring: 'true'
+        name: ${NAMESPACE}
     - apiVersion: monitoring.coreos.com/v1
       kind: ServiceMonitor
       metadata:
         labels:
           control-plane: controller-manager
         name: controller-manager-metrics-monitor
-        namespace: openshift-monitoring
+        namespace: ${NAMESPACE}
       spec:
         endpoints:
         - path: /metrics
@@ -81,3 +87,9 @@ objects:
         name: ${REPO_NAME}
         source: ${REPO_NAME}-registry
         sourceNamespace: ${NAMESPACE}
+    - apiVersion: operators.coreos.com/v1alpha2
+      kind: OperatorGroup
+      metadata:
+        name: route-monitor-operator
+        namespace: ${NAMESPACE}
+      spec: {}

--- a/hack/templates/template.yaml
+++ b/hack/templates/template.yaml
@@ -6,7 +6,7 @@ parameters:
 - name: IMAGE_TAG
   required: true
 - name: NAMESPACE # a new flag as Route Monitor Operator operates in openshift-monitoring namespace
-  value: openshift-monitoring
+  value: openshift-route-monitor-operator
 - name: REGISTRY_IMG
   required: true
 - name: REPO_NAME


### PR DESCRIPTION
- 'make generate-syncset' now generates the namespace and the operatorgroup
- config/olm has a namespace parameter for overriding the namespace in the deployment pipeline
