### PR TITLE
Delete spec field from OperatorGroup

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -64,6 +64,5 @@ objects:
     - apiVersion: operators.coreos.com/v1alpha2
       kind: OperatorGroup
       metadata:
-        name: route-monitor-operator
+        name: ${REPO_NAME}
         namespace: ${NAMESPACE}
-      spec: {}


### PR DESCRIPTION
Got some non-matching operatorgroup errors on stage. This fixes them, and configures the operatorgroup for all namespaces (per the CSV spec).