### PR TITLE
Autorun `make generate-syncsets` via GitHub actions

### DIFF
--- a/.github/workflows/makecommit.yml
+++ b/.github/workflows/makecommit.yml
@@ -1,0 +1,21 @@
+name: Make Generate
+on: push
+
+jobs:
+  run:
+    name: Make Generate Template
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Make
+      run: make generate-syncsets
+
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v4
+      with:
+        message: "make generate-syncsets"
+        add: "hack/olm-registry/olm-artifacts-template.yaml"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/makecommit.yml
+++ b/.github/workflows/makecommit.yml
@@ -10,12 +10,12 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Make
-      run: make generate-syncsets
+      run: make generate-syncset
 
     - name: Commit changes
       uses: EndBug/add-and-commit@v4
       with:
-        message: "make generate-syncsets"
+        message: "make generate-syncset"
         add: "hack/olm-registry/olm-artifacts-template.yaml"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/makecommit.yml
+++ b/.github/workflows/makecommit.yml
@@ -13,7 +13,7 @@ jobs:
       run: make generate-syncset
 
     - name: Commit changes
-      uses: EndBug/add-and-commit@v4
+      uses: EndBug/add-and-commit@v7
       with:
         message: "make generate-syncset"
         add: "hack/olm-registry/olm-artifacts-template.yaml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Folow a simple workflow:
 * Create Issue to explain what is wrong or missing
 * Fork this repository
 * Create a Pull Request referencing the issue you're adressing
+* enabled GitHub actions on your fork to automatically run generation steps
 * Make sure all tests are passing
 * Follow the bot instructions
 

--- a/hack/generate-syncset.sh
+++ b/hack/generate-syncset.sh
@@ -2,8 +2,13 @@
 
 set -euxo pipefail
 
-CONTAINER_ENGINE=${CONAINER_ENGINE:-docker}
-IN_CONTAINER=${IN_CONTAINER:-false}
+IN_CONTAINER=${IN_CONTAINER:-true}
+
+if [[ $(which podman) ]]; then
+	CONTAINER_ENGINE=podman
+elif [[ $(which docker) ]]; then
+	CONTAINER_ENGINE=docker
+fi
 # This is a tad ambitious, but it should usually work.
 export REPO_NAME=$(git config --get remote.origin.url | sed 's,.*/,,; s/\.git$//')
 # If that still didn't work, warn (but proceed)


### PR DESCRIPTION
This adds GitHub actions that automatically run after you committed, to save users from that extra step