### PR TITLE
[OSD-6345] fix: Make changes to OLM template permanent

### DIFF
--- a/config/olm/operatorgroup.yaml
+++ b/config/olm/operatorgroup.yaml
@@ -1,5 +1,4 @@
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
-  name: route-monitor-operator
-spec: {}
+  name: ${REPO_NAME}


### PR DESCRIPTION
Hard coded `name: ${REPO_NAME}` in config/olm/operatorgroup.yaml file.

When running `make generate-syncsets` it doesn't produce any diff in hack/olm-registry/olm-artifacts-template.yaml file.