### PR TITLE
Use IMAGE_DIGEST in OLM template

### DIFF
--- a/config/olm/catalogsource.yaml
+++ b/config/olm/catalogsource.yaml
@@ -6,7 +6,7 @@ metadata:
     opsrc-provider: redhat
   name: ${REPO_NAME}-registry
 spec:
-  image: ${REPO_DIGEST}
+  image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
   displayName: ${REPO_NAME}
   icon:
     base64data: ''

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -5,7 +5,7 @@ parameters:
   required: true
 - name: IMAGE_TAG
   required: true
-- name: REPO_DIGEST
+- name: IMAGE_DIGEST
   required: true
 - name: NAMESPACE
   value: openshift-route-monitor-operator
@@ -50,7 +50,7 @@ objects:
         icon:
           base64data: ''
           mediatype: ''
-        image: ${REPO_DIGEST}
+        image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         publisher: Red Hat
         sourceType: grpc
     - apiVersion: operators.coreos.com/v1alpha1

--- a/hack/templates/template.yaml
+++ b/hack/templates/template.yaml
@@ -5,7 +5,7 @@ parameters:
   required: true
 - name: IMAGE_TAG
   required: true
-- name: REPO_DIGEST
+- name: IMAGE_DIGEST
   required: true
 - name: NAMESPACE # a new flag as Route Monitor Operator operates in openshift-monitoring namespace
   value: openshift-route-monitor-operator


### PR DESCRIPTION
To make the OLM template easier to understand, replace `${REPO_DIGEST}` with `${REGISTRY_IMG}@${IMAGE_DIGEST}`.

`IMAGE_DIGEST` is supported as of APPSRE-3265.