### PR TITLE
Jira OSD-6297: Revert alertName parameter in templates.go

### DIFF
--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
@@ -116,7 +116,7 @@ func (s *ClusterUrlMonitorSupplement) EnsurePrometheusRuleResourceExists() (util
 	namespacedName := types.NamespacedName{Namespace: s.ClusterUrlMonitor.Namespace, Name: s.ClusterUrlMonitor.Name}
 	spec := s.ClusterUrlMonitor.Spec
 	clusterUrl := spec.Prefix + clusterDomain + ":" + spec.Port + spec.Suffix
-	template := templates.TemplateForPrometheusRuleResource(clusterUrl, parsedSlo, namespacedName, s.ClusterUrlMonitor.Kind)
+	template := templates.TemplateForPrometheusRuleResource(clusterUrl, parsedSlo, namespacedName)
 
 	err = s.createOrUpdatePrometheusRule(template)
 	if err != nil {

--- a/controllers/routemonitor/routemonitor_supplement.go
+++ b/controllers/routemonitor/routemonitor_supplement.go
@@ -81,7 +81,7 @@ func (r *RouteMonitorReconciler) EnsurePrometheusRuleResourceExists(ctx context.
 	}
 
 	namespacedName := types.NamespacedName{Namespace: routeMonitor.Namespace, Name: routeMonitor.Name}
-	template := templates.TemplateForPrometheusRuleResource(routeMonitor.Status.RouteURL, parsedSlo, namespacedName, routeMonitor.Kind)
+	template := templates.TemplateForPrometheusRuleResource(routeMonitor.Status.RouteURL, parsedSlo, namespacedName)
 
 	err = r.createOrUpdatePrometheusRule(ctx, template)
 	if err != nil {

--- a/int/integration.go
+++ b/int/integration.go
@@ -224,7 +224,7 @@ func (i *Integration) RouteMonitorWaitForPrometheusRuleCorrectSLO(name types.Nam
 		return err
 	}
 
-	template := templates.TemplateForPrometheusRuleResource(routeMonitor.Status.RouteURL, targetSlo, name, "RouteMonitor")
+	template := templates.TemplateForPrometheusRuleResource(routeMonitor.Status.RouteURL, targetSlo, name)
 	t := 0
 	for ; t < seconds; t++ {
 		err := i.Client.Get(context.TODO(), name, &prometheusRule)
@@ -261,7 +261,7 @@ func (i *Integration) ClusterUrlMonitorWaitForPrometheusRuleCorrectSLO(name type
 		return err
 	}
 
-	template := templates.TemplateForPrometheusRuleResource(expectedUrl, targetSlo, name, "ClusterUrlMonitor")
+	template := templates.TemplateForPrometheusRuleResource(expectedUrl, targetSlo, name)
 	t := 0
 	for ; t < seconds; t++ {
 		err := i.Client.Get(context.TODO(), name, &prometheusRule)


### PR DESCRIPTION
Remove _alertName_ parameter from monitoring rule expression which was causing clusterurlmonitor alert to not fire.