### PR TITLE
Add short intro tour

### DIFF
--- a/.tours/rmo-intro.tour
+++ b/.tours/rmo-intro.tour
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "RMO Intro",
+  "steps": [
+    {
+      "title": "Introduction",
+      "description": "Welcome to the CodeTour into Route Monitor Operator (RMO). Have fun exploring this code base!"
+    },
+    {
+      "file": "main.go",
+      "description": "RMO uses Operator SDK v1.0+. This line in main.go is where the control loop is started for the watched objects: RouteMonitors & ClusterUrlMonitors.",
+      "line": 127
+    },
+    {
+      "file": "main.go",
+      "description": "RouteMonitors use the RouteMonitor controller, which uses these internal structures to operate on. They are initialized once for the runtime of the application.",
+      "line": 102
+    },
+    {
+      "file": "main.go",
+      "description": "The ClusterUrlMonitor controller is set up a bit differently. All depending structures are initialized during the reconciliation, so they live for only one run on Reconcile().",
+      "line": 113
+    },
+    {
+      "file": "controllers/routemonitor/routemonitor.go",
+      "description": "This is the entrypoint to Reconciling RouteMonitor resources. A RouteMonitor is used to specify an OpenShift route that will be observed by synthetic probes.\nThe `Reconcile` function will be called each time a RouteMonitor is created or updated.",
+      "line": 52
+    },
+    {
+      "file": "controllers/routemonitor/routemonitor.go",
+      "description": "the `Reconcile` function is split into idempotent subroutines which are executed for each run. This specific step makes sure the BlackBoxExporter, which is used for the synthetic probing, is deployed (i.e. the `Deployment` is created)",
+      "line": 93
+    },
+    {
+      "file": "controllers/routemonitor/routemonitor.go",
+      "description": "The implementation of all steps related to RouteMonitors is split into 3 different parts:\n`RouteMonitorAdder` contains everything related to a new or updated RouteMonitor",
+      "line": 39
+    },
+    {
+      "file": "controllers/routemonitor/routemonitor.go",
+      "description": "`RouteMonitorDeleter` contains everything related to cleaning up when a RouteMonitor is removed",
+      "line": 40
+    },
+    {
+      "file": "controllers/routemonitor/routemonitor.go",
+      "description": "`RouteMonitorSupplement` is a generic supplement that contains everyting that's independent of creating or removing resources",
+      "line": 38
+    },
+    {
+      "file": "controllers/clusterurlmonitor/clusterurlmonitor.go",
+      "description": "The reconciliation of ClusterUrlMonitor resources is split up a bit different. Reconcile is again the entrypoint for a single request, but the actual processing is done in `ProcessRequest`. `Reconcile` only wraps this function and creates the depending resources.",
+      "line": 70
+    },
+    {
+      "file": "controllers/clusterurlmonitor/clusterurlmonitor_supplement.go",
+      "description": "This function is where the actual processing of a requerst for ClusterUrlMonitors is done. ClusterUrlMonitors can be used to create monitoring of arbitrary URLs in an OpenShift cluster.",
+      "line": 316
+    },
+    {
+      "file": "pkg/util/templates/templates.go",
+      "description": "functionality that is common between the RouteMonitor and ClusterUrlMonitor processing is located in the pkg folder. This file contains all resource templates that the operator creates, like ServiceMonitors or PrometheusRules.",
+      "line": 23
+    },
+    {
+      "file": "pkg/blackboxexporter/blackboxexporter.go",
+      "description": "A BlackBoxExporter is deployed as soon as at least one resource is observed by the operator. It's used to probe the specified URLs.",
+      "line": 66
+    },
+    {
+      "file": "controllers/clusterurlmonitor/clusterurlmonitor_test.go",
+      "description": "We use Ginkgo and Gomega for our test suite.",
+      "line": 389
+    },
+    {
+      "file": "int/int_test.go",
+      "description": "In addition to unit tests we have a suite of integration tests that can be run with `make test-integration`. You can also execute the against an OpenShift cluster you're currently logged in with `go test ./int`.\nThese tests create resources in the cluster and observe if the outcome matches the expected outcome. This test for example creates a ClusterUrlMonitor and expects a ServiceMonitor to show up.",
+      "line": 69
+    }
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "vsls-contrib.codetour"
+    ]
+}


### PR DESCRIPTION
Adding a code intro tour.

To test the tour without checking out the code, go to https://github1s.com/NautiluX/route-monitor-operator/tree/tour install recommended extensions (bottom right popup) and start the tour.