### PR TITLE
fix: make generate will fail on config change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ all: manager
 TESTS=$(shell go list ./... | grep -v /int | tr '\n' ' ')
 
 # Run tests
-test: generate fmt vet manifests 
+test: generate fmt vet
 	go test $(TESTS) -coverprofile cover.out
 
 # Build manager binary
@@ -48,11 +48,11 @@ manager: generate fmt vet
 	go build -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet manifests
+run: generate fmt vet
 	go run ./main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run-verbose: generate fmt vet manifests
+run-verbose: generate fmt vet
 	go run ./main.go --zap-log-level=5
 
 # Install CRDs into a cluster
@@ -91,7 +91,7 @@ vet:
 	go vet ./...
 
 # Generate code
-generate: mockgen controller-gen
+generate: mockgen controller-gen manifests
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 test-integration:

--- a/controllers/routemonitor/routemonitor.go
+++ b/controllers/routemonitor/routemonitor.go
@@ -70,7 +70,7 @@ func NewReconciler(mgr manager.Manager, blackboxExporterImage, blackboxExporterN
 // +kubebuilder:rbac:groups=monitoring.openshift.io,resources=routemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.openshift.io,resources=routemonitors/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 
 func (r *RouteMonitorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	r.Ctx = context.Background()

--- a/controllers/routemonitor/routemonitor.go
+++ b/controllers/routemonitor/routemonitor.go
@@ -70,7 +70,7 @@ func NewReconciler(mgr manager.Manager, blackboxExporterImage, blackboxExporterN
 // +kubebuilder:rbac:groups=monitoring.openshift.io,resources=routemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.openshift.io,resources=routemonitors/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch
-// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch;patch
 
 func (r *RouteMonitorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	r.Ctx = context.Background()


### PR DESCRIPTION
in the release repo https://github.com/openshift/release/blob/master/ci-operator/config/openshift/route-monitor-operator/openshift-route-monitor-operator-master.yaml#L21
the make generate is invoked and then tested for local file changes,
thus adding the manifests there will ensure the code will fail if the generation is incomplete
