### PR TITLE
OSD-7984: use ubi-minimal as base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot


### PR DESCRIPTION
There is not more to do, it just works: 
Checked it here:
https://quay.io/repository/rbutter/route-monitor-operator/manifest/sha256:f880d65a7a07c7d89bc50898ec46930acd4f5d18a9c878c490e2c34deed807b5?tab=vulnerabilities