### PR TITLE
fix(pipeline): add gcc [OSD-6289]

### DIFF
--- a/hack/pipeline.dockerfile
+++ b/hack/pipeline.dockerfile
@@ -14,7 +14,7 @@ RUN ~/go/bin/kustomize version
 FROM quay.io/operator-framework/operator-sdk:v1.13.1
 
 # We need git to clone our repo
-RUN microdnf install -y git
+RUN microdnf install -y git gcc
 # Clean up after install
 RUN rm -rf /.cache
 # Copy kustomize binary from builder 


### PR DESCRIPTION
seems the newer version of the operator-sdk doesn't include a required package to run the go build, so added now
