### PR TITLE
Removed empty icon spec

### DIFF
--- a/config/manifests/bases/route-monitor-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/route-monitor-operator.clusterserviceversion.yaml
@@ -25,9 +25,6 @@ spec:
   description: Automatically enables blackbox probes for routes on OpenShift clusters
     to be consumed by the Cluster Monitoring Operator or any vanilla Prometheus Operator
   displayName: Route Monitor Operator
-  icon:
-  - base64data: ""
-    mediatype: ""
   install:
     spec:
       deployments: null


### PR DESCRIPTION
Empty icon spec in ClusterServiceVersion manifest seems to be resulting in a missing icon in the console's Installed Operators list view, overriding the default icon:

![Screen Shot 2021-11-26 at 11 48 16 AM](https://user-images.githubusercontent.com/49566756/143611688-e0d3e774-c237-4c88-a268-cc34125699a8.png)

Removing empty icon spec to allow default icon to display.