### PR TITLE
chore(github-action): fix local build

### DIFF
--- a/.github/workflows/makecommit.yml
+++ b/.github/workflows/makecommit.yml
@@ -15,7 +15,7 @@ jobs:
         CONTAINER_ENGINE: docker
 
     - name: Commit changes
-      uses: EndBug/add-and-commit@v7
+      uses: EndBug/add-and-commit@v8.0.1
       with:
         message: "make generate-syncset"
         add: "hack/olm-registry/olm-artifacts-template.yaml"

--- a/.github/workflows/makecommit.yml
+++ b/.github/workflows/makecommit.yml
@@ -11,6 +11,8 @@ jobs:
 
     - name: Make
       run: make generate-syncset
+      env:
+        CONTAINER_ENGINE: docker
 
     - name: Commit changes
       uses: EndBug/add-and-commit@v7


### PR DESCRIPTION
the local build would use `podman` and that would fail on an issue I didn't want to tackle

moving to `docker` fixed it