### PR TITLE
chore(deps): bump openshift/origin-operator-registry from 4.5 to 4.10.0

### DIFF
--- a/packagemanifests.Dockerfile
+++ b/packagemanifests.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-operator-registry:4.5
+FROM quay.io/openshift/origin-operator-registry:4.10.0
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/

--- a/packagemanifests.Dockerfile
+++ b/packagemanifests.Dockerfile
@@ -1,3 +1,5 @@
+# to build this, use the 'make packagemanifests-build' command
+
 FROM quay.io/openshift/origin-operator-registry:4.10.0
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
Bumps openshift/origin-operator-registry from 4.5 to 4.10.0.

---
updated-dependencies:
- dependency-name: openshift/origin-operator-registry
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>