### PR TITLE
[OSD-10503] build(Dockerfile): update base image to ubi-micro

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/hack/pipeline.dockerfile
+++ b/hack/pipeline.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS kustomize-builder
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest AS kustomize-builder
 
 RUN microdnf install -y golang make which
 RUN microdnf install -y git


### PR DESCRIPTION
This change is to make sure there are no critical or high vulnerabilities in base image