### PR TITLE
fix(pipeline.dockerfile): revert base image change

### DIFF
--- a/hack/pipeline.dockerfile
+++ b/hack/pipeline.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.5-836 AS kustomize-builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS kustomize-builder
 
 RUN microdnf install -y golang make which
 RUN microdnf install -y git


### PR DESCRIPTION
Due to lack of microdnf package in ubi-micro image, build pipeline is currently failing. Hence this PR.
Will follow up by checking if there can be workaround for required packages such as make, which and gcc. Then we could use ubi-micro image.