### PR TITLE
standarise on cluster uuid key [OSD-11971]

### DIFF
--- a/pkg/servicemonitor/servicemonitor.go
+++ b/pkg/servicemonitor/servicemonitor.go
@@ -121,7 +121,7 @@ func TemplateForServiceMonitorResource(url, blackBoxExporterNamespace string, na
 						},
 						{
 							Replacement: clusterID,
-							TargetLabel: "ClusterID",
+							TargetLabel: "_id",
 						},
 					},
 				}},


### PR DESCRIPTION
The current key for the cluster uuid is unique to where these values are being referenced elsewhere. This PR is about standardising this key, especially in regards to hypershift. [OSD-11971](https://issues.redhat.com//browse/OSD-11971)