### PR TITLE
chore: add new approvers, remove RH alumni

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,13 +2,13 @@ maintainers:
 - NautiluX
 approvers:
 - NautiluX
-- georgettica
-- rafael-azevedo
-reviewers:
-- NautiluX
-- georgettica
-- rafael-azevedo
-- ramonbutter
 - Tessg22
 - ninabauer
+- rafael-azevedo
+- shibumi
+reviewers:
+- NautiluX
+- Tessg22
+- ninabauer
+- rafael-azevedo
 - shibumi


### PR DESCRIPTION
This commit adds more approvers for a more fluent development experience.
Also, it removes two former RH members.