### PR TITLE
OHSS-14525 Removal of leaver shibumi from owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,10 +5,8 @@ approvers:
 - Tessg22
 - ninabauer
 - rafael-azevedo
-- shibumi
 reviewers:
 - NautiluX
 - Tessg22
 - ninabauer
 - rafael-azevedo
-- shibumi


### PR DESCRIPTION
Step [12.3.3](https://github.com/openshift/ops-sop/blob/master/security/leaver_process.asciidoc#1233-review-users-owners-permissions) of the leaver process SOP includes removal from our openshift repos. Hence, this PR serves the removal of Christian Rebischke.