### PR TITLE
Remove deploy/package.yaml

### DIFF
--- a/deploy/package.yaml
+++ b/deploy/package.yaml
@@ -1,6 +1,0 @@
-apiVersion: package-operator.run/v1alpha1
-kind: Package
-metadata:
-  name: route-monitor-operator
-spec:
-  image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-5f4163e


### PR DESCRIPTION
Boilerplate is erroring with `UnsupportedRegistUnsupportedRegistryResourceKind: The resource at deploy/package.yaml of kind Package is not supportedryResourceKind: The resource at deploy/package.yaml of kind Package is not supported`

Removing deploy/package.yaml as this isn't being used by RMO directly, but more of an example. 

TBD where file will be placed.