### PR TITLE
the yq make target is a prerequisite for the package target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ ifeq (,$(wildcard bin/kubectl-package))
 endif
 
 .PHONY: package
-package:
+package: yq
 	$(YQ) '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
 	./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:$(OPERATOR_IMAGE_TAG) --push packaging/
 


### PR DESCRIPTION
sets up `make yq` as a prerequisite for `make package`, ensuring that the yq binary is available for use in the `make package` target