### PR TITLE
ensure kubectl-package is present for package make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ ifeq (,$(wildcard bin/kubectl-package))
 endif
 
 .PHONY: package
-package: yq
+package: yq kubectl-package
 	$(YQ) '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
 	./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:$(OPERATOR_IMAGE_TAG) --push packaging/
 


### PR DESCRIPTION
if the kubectl-package binary isn't present, download it for use in the
  `make package` target