### PR TITLE
hostedcluster --> hostedclusters K8s RBAC bugfix

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -52,7 +52,7 @@ rules:
 - apiGroups:
   - hypershift.openshift.io
   resources:
-  - hostedcluster
+  - hostedclusters
   verbs:
   - get
   - list

--- a/controllers/clusterurlmonitor/clusterurlmonitor.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor.go
@@ -78,7 +78,7 @@ const (
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedcontrolplanes,verbs=get;list;watch
-// +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedcluster,verbs=get;list;watch
+// +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;list;watch
 
 func (r *ClusterUrlMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Ctx = ctx

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -54,7 +54,7 @@ rules:
   - apiGroups:
       - hypershift.openshift.io
     resources:
-      - hostedcluster
+      - hostedclusters
     verbs:
       - get
       - list


### PR DESCRIPTION
Due to logs seen in staging:
```
❯ k logs -n openshift-route-monitor-operator route-monitor-operator-controller-manager-764788c7d5-d8v9b --tail 2 
W0322 16:04:12.638544       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.2/tools/cache/reflector.go:169: failed to list *v1beta1.HostedCluster: hostedclusters.hypershift.openshift.io is forbidden: User "system:serviceaccount:openshift-route-monitor-operator:route-monitor-operator-system" cannot list resource "hostedclusters" in API group "hypershift.openshift.io" at the cluster scope
E0322 16:04:12.638571       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.25.2/tools/cache/reflector.go:169: Failed to watch *v1beta1.HostedCluster: failed to list *v1beta1.HostedCluster: hostedclusters.hypershift.openshift.io is forbidden: User "system:serviceaccount:openshift-route-monitor-operator:route-monitor-operator-system" cannot list resource "hostedclusters" in API group "hypershift.openshift.io" at the cluster scope
```