### PR TITLE
Add .spec.skipPrometheusRule to the RouteMonitor CRD in order to... 

### DIFF
--- a/api/v1alpha1/routemonitor_types.go
+++ b/api/v1alpha1/routemonitor_types.go
@@ -20,16 +20,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // RouteMonitorSpec defines the desired state of RouteMonitor
 type RouteMonitorSpec struct {
 	Route RouteMonitorRouteSpec `json:"route,omitempty"`
 	Slo   SloSpec               `json:"slo,omitempty"`
+
+	// +kubebuilder:default:false
+	// +kubebuilder:validation:Optional
+
+	// SkipPrometheusRule instructs the controller to skip the creation of PrometheusRule CRs.
+	// One common use-case for is for alerts that are defined separately, such as for hosted clusters.
+	SkipPrometheusRule bool `json:"skipPrometheusRule"`
 }
 
-// RouteMonitorSpec references the obsered Route resource
+// RouteMonitorRouteSpec references the observed Route resource
 type RouteMonitorRouteSpec struct {
 	// Name is the name of the Route
 	Name string `json:"name,omitempty"`

--- a/config/crd/bases/monitoring.openshift.io_routemonitors.yaml
+++ b/config/crd/bases/monitoring.openshift.io_routemonitors.yaml
@@ -36,7 +36,7 @@ spec:
             description: RouteMonitorSpec defines the desired state of RouteMonitor
             properties:
               route:
-                description: RouteMonitorSpec references the obsered Route resource
+                description: RouteMonitorRouteSpec references the observed Route resource
                 properties:
                   name:
                     description: Name is the name of the Route
@@ -45,6 +45,11 @@ spec:
                     description: Namespace is the namespace of the Route
                     type: string
                 type: object
+              skipPrometheusRule:
+                description: SkipPrometheusRule instructs the controller to skip the
+                  creation of PrometheusRule CRs. One common use-case for is for alerts
+                  that are defined separately, such as for hosted clusters.
+                type: boolean
               slo:
                 description: SloSpec defines what is the percentage
                 properties:

--- a/deploy/crds/monitoring.openshift.io_routemonitors.yaml
+++ b/deploy/crds/monitoring.openshift.io_routemonitors.yaml
@@ -36,7 +36,7 @@ spec:
             description: RouteMonitorSpec defines the desired state of RouteMonitor
             properties:
               route:
-                description: RouteMonitorSpec references the obsered Route resource
+                description: RouteMonitorRouteSpec references the observed Route resource
                 properties:
                   name:
                     description: Name is the name of the Route
@@ -45,6 +45,11 @@ spec:
                     description: Namespace is the namespace of the Route
                     type: string
                 type: object
+              skipPrometheusRule:
+                description: SkipPrometheusRule instructs the controller to skip the
+                  creation of PrometheusRule CRs. One common use-case for is for alerts
+                  that are defined separately, such as for hosted clusters.
+                type: boolean
               slo:
                 description: SloSpec defines what is the percentage
                 properties:

--- a/deploy/routemonitors.monitoring.openshift.io.CustomResourceDefinition.yaml
+++ b/deploy/routemonitors.monitoring.openshift.io.CustomResourceDefinition.yaml
@@ -33,7 +33,7 @@ spec:
               description: RouteMonitorSpec defines the desired state of RouteMonitor
               properties:
                 route:
-                  description: RouteMonitorSpec references the obsered Route resource
+                  description: RouteMonitorRouteSpec references the observed Route resource
                   properties:
                     name:
                       description: Name is the name of the Route
@@ -42,6 +42,9 @@ spec:
                       description: Namespace is the namespace of the Route
                       type: string
                   type: object
+                skipPrometheusRule:
+                  description: SkipPrometheusRule instructs the controller to skip the creation of PrometheusRule CRs. One common use-case for is for alerts that are defined separately, such as for hosted clusters.
+                  type: boolean
                 slo:
                   description: SloSpec defines what is the percentage
                   properties:


### PR DESCRIPTION
ensure no PrometheusRule exists when configured.

[OSD-16127](https://issues.redhat.com//browse/OSD-16127)

This PR does this by adding a new field which will cause the controller to delete existing PrometheusRules that are mentioned in `.status.PrometheusRuleRef`, otherwise if `.status.PrometheusRuleRef` is empty, just skip the creation.