### PR TITLE
Make catalogsource c ompatible with restricted SCC enforcement

### DIFF
--- a/config/olm/catalogsource.yaml
+++ b/config/olm/catalogsource.yaml
@@ -13,3 +13,5 @@ spec:
     mediatype: ''
   publisher: Red Hat
   sourceType: grpc
+  grpcPodConfig:
+    securityContextConfig: restricted

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -55,6 +55,8 @@ objects:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         publisher: Red Hat
         sourceType: grpc
+        grpcPodConfig:
+          securityContextConfig: restricted
     - apiVersion: operators.coreos.com/v1alpha1
       kind: Subscription
       metadata:


### PR DESCRIPTION
* Restricted SCC enforcement will come with OCP 4.14
* Updating the catalogsource to allow operator to get deployed

Jira: [OSD-15617](https://issues.redhat.com//browse/OSD-15617)