### PR TITLE
Add hypershift-package template to deploy via PKO

### DIFF
--- a/hack/hypershift-package/hypershift-artifacts-template.yaml
+++ b/hack/hypershift-package/hypershift-artifacts-template.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: selectorsyncset-template
+
+parameters:
+- name: IMAGE_TAG
+  required: true
+- name: REPO_NAME
+  value: route-monitor-operator
+  required: true
+- name: PACKAGE_IMAGE
+  required: true
+- name: PACKAGE_TAG
+  required: true
+
+objects:
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+          annotations:
+              policy.open-cluster-management.io/categories: CM Configuration Management
+              policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+              policy.open-cluster-management.io/standards: NIST SP 800-53
+          name: hs-mgmt-route-monitor-operator
+          namespace: openshift-acm-policies
+      spec:
+          disabled: false
+          policy-templates:
+              - objectDefinition:
+                  apiVersion: policy.open-cluster-management.io/v1
+                  kind: ConfigurationPolicy
+                  metadata:
+                      name: hs-mgmt-route-monitor-operator
+                  spec:
+                      evaluationInterval:
+                          compliant: 2m
+                          noncompliant: 45s
+                      namespaceSelector:
+                          matchLabels:
+                              hypershift.openshift.io/hosted-control-plane: "true"
+                      object-templates:
+                          - complianceType: mustonlyhave
+                            metadataComplianceType: musthave
+                            objectDefinition:
+                              apiVersion: monitoring.openshift.io/v1alpha1
+                              kind: ClusterUrlMonitor
+                              metadata:
+                                  name: api
+                              spec:
+                                  domainRef: hcp
+                                  port: "443"
+                                  prefix: https://api.
+                                  slo:
+                                      targetAvailabilityPercent: "99.0"
+                                  suffix: /livez
+                          - complianceType: mustonlyhave
+                            metadataComplianceType: musthave
+                            objectDefinition:
+                              apiVersion: package-operator.run/v1alpha1
+                              kind: Package
+                              metadata:
+                                  name: route-monitor-operator
+                              spec:
+                                image: ${PACKAGE_IMAGE}:${PACKAGE_TAG}
+                      pruneObjectBehavior: DeleteIfCreated
+                      remediationAction: enforce
+                      severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+          name: placement-hs-mgmt-route-monitor-operator
+          namespace: openshift-acm-policies
+      spec:
+          clusterSelector:
+              matchExpressions:
+                  - key: hypershift.open-cluster-management.io/management-cluster
+                    operator: In
+                    values:
+                      - "true"
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+          name: binding-hs-mgmt-route-monitor-operator
+          namespace: openshift-acm-policies
+      placementRef:
+          apiGroup: apps.open-cluster-management.io
+          kind: PlacementRule
+          name: placement-hs-mgmt-route-monitor-operator
+      subjects:
+          - apiGroup: policy.open-cluster-management.io
+            kind: Policy
+            name: hs-mgmt-route-monitor-operator


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-15543

---

Migrates the [existing route-monitor-operator policy](https://github.com/openshift/managed-cluster-config/tree/master/deploy/hs-mgmt-route-monitor-operator) to a template so that Package Operator packages can be promoted alongside normal OLM for HyperShift clusters.