### PR TITLE
OSD-15543 - Fix the hypershift syncset name

### DIFF
--- a/hack/hypershift-package/hypershift-artifacts-template.yaml
+++ b/hack/hypershift-package/hypershift-artifacts-template.yaml
@@ -22,7 +22,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: route-monitor-operator
+    name: hs-mgmt-route-monitor-operator
   spec:
     clusterDeploymentSelector:
       matchLabels:


### PR DESCRIPTION
Fixes the syncset's name for the hypershift mgmt cluster package so it no longer collides w/ the default OSD/ROSA one