### PR TITLE
Update clusterurlmonitor to use the private NLB domain for private HCPs

### DIFF
--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/route-monitor-operator/pkg/alert"
 	blackboxexporterconsts "github.com/openshift/route-monitor-operator/pkg/consts/blackboxexporter"
 	utilreconcile "github.com/openshift/route-monitor-operator/pkg/util/reconcile"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -214,11 +215,25 @@ func (s *ClusterUrlMonitorReconciler) getHypershiftClusterDomain(monitor v1alpha
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve HostedControlPlane for hosted cluster: %w", err)
 	}
-
 	clusterAnnotation := clusterHCP.Annotations[hcpClusterAnnotation]
 	annotationTokens := strings.Split(clusterAnnotation, "/")
 	if len(annotationTokens) != 2 {
 		return "", fmt.Errorf("invalid annotation for HostedControlPlane '%s': expected <namespace>/<hostedcluster name>, got %s", clusterHCP.Name, clusterAnnotation)
+	}
+
+	endpointAccess := clusterHCP.Spec.Platform.AWS.EndpointAccess
+
+	// In the case of private clusters, the domain will be the ingress of the private router
+	if endpointAccess == hypershiftv1beta1.Private {
+		service := corev1.Service{}
+		err := s.Client.Get(s.Ctx, types.NamespacedName{Name: "private-router", Namespace: monitor.Namespace}, &service)
+		if err != nil {
+			return "", fmt.Errorf("could not retrieve private router in namespace '%s'; Reason: %s", monitor.Namespace, err.Error())
+		}
+
+		ingress := service.Status.LoadBalancer.Ingress[0].Hostname
+		fmt.Printf("here with %s\n", ingress)
+		return ingress, nil
 	}
 
 	// Retrieve hostedCluster using HCP annotation

--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
@@ -226,13 +226,23 @@ func (s *ClusterUrlMonitorReconciler) getHypershiftClusterDomain(monitor v1alpha
 	// In the case of private clusters, the domain will be the ingress of the private router
 	if endpointAccess == hypershiftv1beta1.Private {
 		service := corev1.Service{}
-		err := s.Client.Get(s.Ctx, types.NamespacedName{Name: "private-router", Namespace: monitor.Namespace}, &service)
+		query := types.NamespacedName{
+			Name:      "private-router",
+			Namespace: monitor.Namespace,
+		}
+
+		err := s.Client.Get(s.Ctx, query, &service)
 		if err != nil {
 			return "", fmt.Errorf("could not retrieve private router in namespace '%s'; Reason: %s", monitor.Namespace, err.Error())
 		}
 
+		// Ensure all load balancers are available before attempting to check ingress
+		condition := meta.FindStatusCondition(clusterHCP.Status.Conditions, string(hypershiftv1beta1.InfrastructureReady))
+		if condition == nil || condition.Status != metav1.ConditionTrue {
+			return "", fmt.Errorf("cluster infrastructure is not yet available")
+		}
+
 		ingress := service.Status.LoadBalancer.Ingress[0].Hostname
-		fmt.Printf("here with %s\n", ingress)
 		return ingress, nil
 	}
 

--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
@@ -242,8 +242,11 @@ func (s *ClusterUrlMonitorReconciler) getHypershiftClusterDomain(monitor v1alpha
 			return "", fmt.Errorf("cluster infrastructure is not yet available")
 		}
 
-		ingress := service.Status.LoadBalancer.Ingress[0].Hostname
-		return ingress, nil
+		ingresses := service.Status.LoadBalancer.Ingress
+		if len(ingresses) > 0 {
+			return ingresses[0].Hostname, nil
+		}
+		return "", fmt.Errorf("ingresses are not available")
 	}
 
 	// Retrieve hostedCluster using HCP annotation

--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement_test.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement_test.go
@@ -68,6 +68,13 @@ var _ = Describe("ClusterUrlMonitorSupplement", func() {
 							"hypershift.openshift.io/cluster": "test-ns/test-hc",
 						},
 					},
+					Spec: hypershiftv1beta1.HostedControlPlaneSpec{
+						Platform: hypershiftv1beta1.PlatformSpec{
+							AWS: &hypershiftv1beta1.AWSPlatformSpec{
+								EndpointAccess: hypershiftv1beta1.Public,
+							},
+						},
+					},
 				}
 				hc := hypershiftv1beta1.HostedCluster{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Currently clusterurlmonitor attempts to use a public endpoint for private clusters, causing both inaccurate and unnecessary alerts.

Closes https://issues.redhat.com/browse/OSD-17069