### PR TITLE
Update hs-mgmt SSS to deploy only to management clusters

### DIFF
--- a/hack/hypershift-package/hypershift-artifacts-template.yaml
+++ b/hack/hypershift-package/hypershift-artifacts-template.yaml
@@ -25,8 +25,16 @@ objects:
     name: hs-mgmt-route-monitor-operator
   spec:
     clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
+      matchExpressions:
+        - key: ext-hypershift.openshift.io/cluster-type
+          operator: In
+          values: ["management-cluster"]
+        - key: api.openshift.com/managed
+          operator: In
+          values: ["true"]
+        - key: api.openshift.com/fedramp
+          operator: NotIn
+          values: ["true"]
     resourceApplyMode: Sync
     resources:
     - apiVersion: policy.open-cluster-management.io/v1


### PR DESCRIPTION
Fixes issues during rollout introduced in #211 where this was getting deployed to all managed clusters

```
  - failureMessage: |-
      failed to apply resource 0: could not get info from passed resource: resource mapping not found for name: "hs-mgmt-route-monitor-operator" namespace: "openshift-acm-policies" from "object": no matches for kind "Policy" in version "policy.open-cluster-management.io/v1"
      ensure CRDs are installed first
    lastTransitionTime: "2023-07-17T03:36:28Z"
    name: hs-mgmt-route-monitor-operator
    observedGeneration: 1
    result: Failure
```

[OSD-15543](https://issues.redhat.com//browse/OSD-15543)