### PR TITLE
Set InsecureSkipTLSVerify true for HyperShift

### DIFF
--- a/pkg/servicemonitor/servicemonitor.go
+++ b/pkg/servicemonitor/servicemonitor.go
@@ -181,9 +181,14 @@ func (u *ServiceMonitor) HyperShiftTemplateForServiceMonitorResource(routeURL, b
 					Interval: rhobsv1.Duration(ServiceMonitorPeriod),
 					// Timeout has to be smaller than probe interval
 					ScrapeTimeout: "15s",
-					Path:          "/probe",
-					Scheme:        "http",
-					Params:        params,
+					TLSConfig: &rhobsv1.TLSConfig{
+						SafeTLSConfig: rhobsv1.SafeTLSConfig{
+							InsecureSkipVerify: true,
+						},
+					},
+					Path:   "/probe",
+					Scheme: "http",
+					Params: params,
 					MetricRelabelConfigs: []*rhobsv1.RelabelConfig{
 						{
 							Replacement: routeURL,


### PR DESCRIPTION
For now, we are healthchecking the load balancer directly for HyperShift, so skip TLS verification

[OSD-17069](https://issues.redhat.com//browse/OSD-17069)