### PR TITLE
Add .spec.skipPrometheusRule to the ClusterURLMonitor CRD in order to…

### DIFF
--- a/api/v1alpha1/clusterurlmonitor_types.go
+++ b/api/v1alpha1/clusterurlmonitor_types.go
@@ -37,6 +37,13 @@ type ClusterUrlMonitorSpec struct {
 	// +kubebuilder:default:="infra"
 	// +optional
 	DomainRef ClusterDomainRef `json:"domainRef,omitempty"`
+
+	// +kubebuilder:default:false
+	// +kubebuilder:validation:Optional
+
+	// SkipPrometheusRule instructs the controller to skip the creation of PrometheusRule CRs.
+	// One common use-case for is for alerts that are defined separately, such as for hosted clusters.
+	SkipPrometheusRule bool `json:"skipPrometheusRule"`
 }
 
 // ClusterDomainRef defines the object used determine the cluster's domain

--- a/config/crd/bases/monitoring.openshift.io_clusterurlmonitors.yaml
+++ b/config/crd/bases/monitoring.openshift.io_clusterurlmonitors.yaml
@@ -50,6 +50,11 @@ spec:
                 description: Foo is an example field of ClusterUrlMonitor. Edit ClusterUrlMonitor_types.go
                   to remove/update
                 type: string
+              skipPrometheusRule:
+                description: SkipPrometheusRule instructs the controller to skip the
+                  creation of PrometheusRule CRs. One common use-case for is for alerts
+                  that are defined separately, such as for hosted clusters.
+                type: boolean
               slo:
                 description: SloSpec defines what is the percentage
                 properties:

--- a/deploy/clusterurlmonitors.monitoring.openshift.io.CustomResourceDefinition.yaml
+++ b/deploy/clusterurlmonitors.monitoring.openshift.io.CustomResourceDefinition.yaml
@@ -43,6 +43,9 @@ spec:
                 prefix:
                   description: Foo is an example field of ClusterUrlMonitor. Edit ClusterUrlMonitor_types.go to remove/update
                   type: string
+                skipPrometheusRule:
+                  description: SkipPrometheusRule instructs the controller to skip the creation of PrometheusRule CRs. One common use-case for is for alerts that are defined separately, such as for hosted clusters.
+                  type: boolean
                 slo:
                   description: SloSpec defines what is the percentage
                   properties:

--- a/deploy/crds/monitoring.openshift.io_clusterurlmonitors.yaml
+++ b/deploy/crds/monitoring.openshift.io_clusterurlmonitors.yaml
@@ -50,6 +50,11 @@ spec:
                 description: Foo is an example field of ClusterUrlMonitor. Edit ClusterUrlMonitor_types.go
                   to remove/update
                 type: string
+              skipPrometheusRule:
+                description: SkipPrometheusRule instructs the controller to skip the
+                  creation of PrometheusRule CRs. One common use-case for is for alerts
+                  that are defined separately, such as for hosted clusters.
+                type: boolean
               slo:
                 description: SloSpec defines what is the percentage
                 properties:


### PR DESCRIPTION
… ensure no PrometheusRule exists when configured

Very similar to #207 where this was done to the RouteMonitor CRD

[OSD-16950](https://issues.redhat.com//browse/OSD-16950)