### PR TITLE
Remove api ClusterURLMonitor from HCP namespaces

### DIFF
--- a/hack/hypershift-package/hypershift-artifacts-template.yaml
+++ b/hack/hypershift-package/hypershift-artifacts-template.yaml
@@ -65,20 +65,6 @@ objects:
                           - complianceType: mustonlyhave
                             metadataComplianceType: musthave
                             objectDefinition:
-                              apiVersion: monitoring.openshift.io/v1alpha1
-                              kind: ClusterUrlMonitor
-                              metadata:
-                                  name: api
-                              spec:
-                                  domainRef: hcp
-                                  port: "443"
-                                  prefix: https://api.
-                                  slo:
-                                      targetAvailabilityPercent: "99.0"
-                                  suffix: /livez
-                          - complianceType: mustonlyhave
-                            metadataComplianceType: musthave
-                            objectDefinition:
                               apiVersion: package-operator.run/v1alpha1
                               kind: Package
                               metadata:


### PR DESCRIPTION
This was moved to HCP workers through
https://github.com/openshift/managed-cluster-config/pull/1757

[OSD-16950](https://issues.redhat.com//browse/OSD-16950)