### PR TITLE
Remove nonexistent yq make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ ifeq (,$(wildcard bin/kubectl-package))
 endif
 
 .PHONY: package
-package: yq kubectl-package
+package: kubectl-package
 	$(YQ) '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
 	$(CONTAINER_ENGINE) login -u $(QUAY_USER) -p $(QUAY_TOKEN) quay.io
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:$(OPERATOR_IMAGE_TAG) --push packaging/


### PR DESCRIPTION
OSD-15779

CI was failing with:
```
make: *** No rule to make target `yq', needed by `package'.  Stop.
```