### PR TITLE
Ensure bin exists for kubectl-package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ boilerplate-update:
 .PHONY: kubectl-package
 kubectl-package:
 ifeq (,$(wildcard bin/kubectl-package))
+	mkdir -p bin
 	wget https://github.com/package-operator/package-operator/releases/latest/download/kubectl-package_$(GOOS)_$(GOARCH) -O bin/kubectl-package
 	chmod 755 bin/kubectl-package
 endif


### PR DESCRIPTION
[OSD-15779](https://issues.redhat.com//browse/OSD-15779)

CI was failing with:
```bash
wget https://github.com/package-operator/package-operator/releases/latest/download/kubectl-package_linux_amd64 -O bin/kubectl-package

bin/kubectl-package: No such file or directory
```
