### PR TITLE
Ensure yq exists in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ endif
 
 .PHONY: package
 package: kubectl-package
-	$(YQ) '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
+	$(CONTAINER_ENGINE) run --rm -i quay.io/app-sre-/yq:4 yq '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
 	$(CONTAINER_ENGINE) login -u $(QUAY_USER) -p $(QUAY_TOKEN) quay.io
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:$(OPERATOR_IMAGE_TAG) --push packaging/
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:latest --push packaging/


### PR DESCRIPTION
```
yq '.spec.template.spec.containers[0].image = "quay.io/app-sre/route-monitor-operator:v0.1.556-813c9fe"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml

bash: yq: command not found
```

This kinda makes me sad, but taken from https://github.com/openshift/route-monitor-operator/blob/master/hack/app_sre_create_image_catalog.sh#L32

[OSD-15779](https://issues.redhat.com//browse/OSD-15779)