### PR TITLE
fix syntax when using docker run and yq:4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ endif
 
 .PHONY: package
 package: kubectl-package
-	$(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:4 yq '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
+	$(CONTAINER_ENGINE) run --rm -v ${PWD}:/workdir quay.io/app-sre/yq:4 yq '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
 	$(CONTAINER_ENGINE) login -u $(QUAY_USER) -p $(QUAY_TOKEN) quay.io
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:$(OPERATOR_IMAGE_TAG) --push packaging/
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:latest --push packaging/


### PR DESCRIPTION
Tested locally with:
```
docker run --rm -v "${PWD}":/workdir quay.io/app-sre/yq:4 '.spec.template.spec.containers[0].image = "quay.io/app-sre/route-monitor-operator:v0.1.560-30a8aaf"' deploy/route-monitor-operator-controller-manager.Deployment.yaml
```

The current error is:
```
docker --config=.docker run --rm -i quay.io/app-sre/yq:4 yq '.spec.template.spec.containers[0].image = "quay.io/app-sre/route-monitor-operator:v0.1.560-30a8aaf"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml

Error: 1:1: invalid input text "yq"
```

[OSD-15779](https://issues.redhat.com//browse/OSD-15779)