### PR TITLE
add hosted cluster monitors to the RMO package

### DIFF
--- a/packaging/07-resources/api.ClusterUrlMonitor.yaml
+++ b/packaging/07-resources/api.ClusterUrlMonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: ClusterUrlMonitor
+metadata:
+  name: api
+  namespace: openshift-route-monitor-operator
+  annotations:
+    package-operator.run/phase: resources
+spec:
+  prefix: https://api.
+  port: "443"
+  suffix: /livez
+  slo:
+    targetAvailabilityPercent: "99.0"
+  skipPrometheusRule: true

--- a/packaging/07-resources/console.RouteMonitor.yaml
+++ b/packaging/07-resources/console.RouteMonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: RouteMonitor
+metadata:
+  annotations:
+    package-operator.run/phase: resources	
+  name: console
+  namespace: openshift-route-monitor-operator
+spec:
+  route:
+    name: console
+    namespace: openshift-console
+  slo:
+    targetAvailabilityPercent: "99.5"
+  skipPrometheusRule: true

--- a/packaging/manifest.yaml
+++ b/packaging/manifest.yaml
@@ -20,6 +20,8 @@ spec:
     class: hosted-cluster
   - name: deploy
     class: hosted-cluster
+  - name: resources
+    class: hosted-cluster
   availabilityProbes:
   - probes:
     - condition:


### PR DESCRIPTION
this will deploy the api and console monitors to hosted clusters as part of the package (instead of relying on an ACM policy in managed-cluster-config to deploy them)