### PR TITLE
Increase memory limits to 400Mi

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 300Mi
+            memory: 400Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -68,7 +68,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 300Mi
+              memory: 400Mi
             requests:
               cpu: 100m
               memory: 20Mi


### PR DESCRIPTION
The controller-manager has been observed consuming 364.9Mi in production

[OHSS-28471](https://issues.redhat.com//browse/OHSS-28471)