### PR TITLE
OSD-21000 - Enable KAS monitoring using internal routes

### DIFF
--- a/api/v1alpha1/routemonitor_types.go
+++ b/api/v1alpha1/routemonitor_types.go
@@ -31,6 +31,13 @@ type RouteMonitorSpec struct {
 	// SkipPrometheusRule instructs the controller to skip the creation of PrometheusRule CRs.
 	// One common use-case for is for alerts that are defined separately, such as for hosted clusters.
 	SkipPrometheusRule bool `json:"skipPrometheusRule"`
+
+	// +kubebuilder:default:false
+	// +kubebuilder:validation:Optional
+
+	// InsecureSkipTLSVerify indicates that the blackbox exporter module used to probe this route
+	// should *not* use https
+	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify"`
 }
 
 // RouteMonitorRouteSpec references the observed Route resource
@@ -39,6 +46,17 @@ type RouteMonitorRouteSpec struct {
 	Name string `json:"name,omitempty"`
 	// Namespace is the namespace of the Route
 	Namespace string `json:"namespace,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum:=1
+
+	// Port optionally defines the port we should use while probing
+	Port int64 `json:"port,omitempty"`
+
+	// +kubebuilder:validation:Optional
+
+	// Suffix optionally defines the path we should probe (/livez /readyz etc)
+	Suffix string `json:"suffix,omitempty"`
 }
 
 // RouteMonitorStatus defines the observed state of RouteMonitor

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,7 @@ rules:
   - '*'
   resources:
   - services
+  - configmaps
   verbs:
   - create
   - delete

--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
@@ -123,7 +123,7 @@ func (s *ClusterUrlMonitorReconciler) EnsureServiceMonitorExists(clusterUrlMonit
 		}
 	}
 
-	if err := s.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(clusterUrl, s.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, isHCP); err != nil {
+	if err := s.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(clusterUrl, s.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, isHCP, false); err != nil {
 		return utilreconcile.RequeueReconcileWith(err)
 	}
 

--- a/controllers/clusterurlmonitor/clusterurlmonitor_test.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Clusterurlmonitor", func() {
 		When("the ServiceMonitor doesn't exist", func() {
 			BeforeEach(func() {
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(1) // fetching domain
-				mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockBlackBoxExporter.EXPECT().GetBlackBoxExporterNamespace().Times(1).Return("")
 				ns := types.NamespacedName{Name: clusterUrlMonitor.Name, Namespace: clusterUrlMonitor.Namespace}
 				mockCommon.EXPECT().GetOSDClusterID().Times(1)

--- a/controllers/interfaces.go
+++ b/controllers/interfaces.go
@@ -63,7 +63,7 @@ type ServiceMonitorHandler interface {
 
 	// TemplateAndUpdateServiceMonitorDeployment will generate a template and then
 	// call UpdateServiceMonitorDeployment to ensure its current state matches the template.
-	TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, hcp bool) error
+	TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, hcp bool, useInsecure bool) error
 
 	// DeleteServiceMonitorDeployment deletes a ServiceMonitor refrenced by a namespaced name
 	DeleteServiceMonitorDeployment(serviceMonitorRef v1alpha1.NamespacedName, hcp bool) error

--- a/controllers/routemonitor/routemonitor.go
+++ b/controllers/routemonitor/routemonitor.go
@@ -63,6 +63,7 @@ func NewReconciler(mgr manager.Manager, blackboxExporterImage, blackboxExporterN
 }
 
 // +kubebuilder:rbac:groups=*,resources=services,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=*,resources=configmaps,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;delete;update
 // +kubebuilder:rbac:groups=monitoring.rhobs,resources=servicemonitors,verbs=get;list;watch;create;delete;update

--- a/controllers/routemonitor/routemonitor_supplement.go
+++ b/controllers/routemonitor/routemonitor_supplement.go
@@ -83,7 +83,7 @@ func (r *RouteMonitorReconciler) EnsureServiceMonitorExists(routeMonitor v1alpha
 		return utilreconcile.RequeueReconcileWith(err)
 	}
 
-	if err := r.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(routeMonitor.Status.RouteURL, r.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, isHCP); err != nil {
+	if err := r.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(routeMonitor.Status.RouteURL, r.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, isHCP, routeMonitor.Spec.InsecureSkipTLSVerify); err != nil {
 		return utilreconcile.RequeueReconcileWith(err)
 	}
 	// update ServiceMonitorRef if required
@@ -198,6 +198,13 @@ func (r *RouteMonitorReconciler) EnsureRouteURLExists(route routev1.Route, route
 
 	if extractedRouteURL == "" {
 		return utilreconcile.RequeueReconcileWith(customerrors.NoHost)
+	}
+
+	if routeMonitor.Spec.Route.Port != 0 {
+		extractedRouteURL = fmt.Sprintf("%s:%d", extractedRouteURL, routeMonitor.Spec.Route.Port)
+	}
+	if routeMonitor.Spec.Route.Suffix != "" {
+		extractedRouteURL = fmt.Sprintf("%s%s", extractedRouteURL, routeMonitor.Spec.Route.Suffix)
 	}
 
 	currentRouteURL := routeMonitor.Status.RouteURL

--- a/controllers/routemonitor/routemonitor_test.go
+++ b/controllers/routemonitor/routemonitor_test.go
@@ -778,7 +778,7 @@ var _ = Describe("Routemonitor", func() {
 		Describe("It updates the ServiceMonitor targeting the blackbox Exporter Namespace", func() {
 			When("the update of the ServiceMonitor fails", func() {
 				BeforeEach(func() {
-					mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(consterror.CustomError)
+					mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(consterror.CustomError)
 					mockBlackboxExporter.EXPECT().GetBlackBoxExporterNamespace().Return("bla")
 					mockUtils.EXPECT().GetOSDClusterID().Return("test-cluster-id", nil)
 				})
@@ -789,7 +789,7 @@ var _ = Describe("Routemonitor", func() {
 			})
 			When("the update of the ServiceMonitor is successfull", func() {
 				BeforeEach(func() {
-					mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+					mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 					mockBlackboxExporter.EXPECT().GetBlackBoxExporterNamespace().Return("bla")
 					mockUtils.EXPECT().GetOSDClusterID().Return("test-cluster-id", nil)
 				})

--- a/deploy/crds/monitoring.openshift.io_routemonitors.yaml
+++ b/deploy/crds/monitoring.openshift.io_routemonitors.yaml
@@ -35,6 +35,10 @@ spec:
           spec:
             description: RouteMonitorSpec defines the desired state of RouteMonitor
             properties:
+              insecureSkipTLSVerify:
+                description: InsecureSkipTLSVerify indicates that the blackbox exporter
+                  module used to probe this route should *not* use https
+                type: boolean
               route:
                 description: RouteMonitorRouteSpec references the observed Route resource
                 properties:
@@ -43,6 +47,16 @@ spec:
                     type: string
                   namespace:
                     description: Namespace is the namespace of the Route
+                    type: string
+                  port:
+                    description: Port optionally defines the port we should use while
+                      probing
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  suffix:
+                    description: Suffix optionally defines the path we should probe
+                      (/livez /readyz etc)
                     type: string
                 type: object
               skipPrometheusRule:

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -19,6 +19,7 @@ rules:
       - '*'
     resources:
       - services
+      - configmaps
     verbs:
       - create
       - delete

--- a/pkg/servicemonitor/servicemonitor.go
+++ b/pkg/servicemonitor/servicemonitor.go
@@ -33,10 +33,14 @@ const (
 	UrlLabelName         string = "probe_url"
 )
 
-func (u *ServiceMonitor) TemplateAndUpdateServiceMonitorDeployment(routeURL, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, isHCPMonitor bool) error {
+func (u *ServiceMonitor) TemplateAndUpdateServiceMonitorDeployment(routeURL, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, isHCPMonitor bool, useInsecure bool) error {
+	module := "http_2xx"
+	if useInsecure {
+		module = "insecure_http_2xx"
+	}
+
 	params := map[string][]string{
-		// Currently we only support `http_2xx` as module
-		"module": {"http_2xx"},
+		"module": {module},
 		"target": {routeURL},
 	}
 
@@ -49,6 +53,7 @@ func (u *ServiceMonitor) TemplateAndUpdateServiceMonitorDeployment(routeURL, bla
 }
 
 // Creates or Updates Service Monitor Deployment according to the template
+
 func (u *ServiceMonitor) UpdateServiceMonitorDeployment(template monitoringv1.ServiceMonitor) error {
 	namespacedName := types.NamespacedName{Name: template.Name, Namespace: template.Namespace}
 	deployedServiceMonitor := &monitoringv1.ServiceMonitor{}

--- a/pkg/util/test/generated/mocks/controllers/interfaces.go
+++ b/pkg/util/test/generated/mocks/controllers/interfaces.go
@@ -241,17 +241,17 @@ func (mr *MockServiceMonitorHandlerMockRecorder) HypershiftUpdateServiceMonitorD
 }
 
 // TemplateAndUpdateServiceMonitorDeployment mocks base method.
-func (m *MockServiceMonitorHandler) TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, hcp bool) error {
+func (m *MockServiceMonitorHandler) TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, hcp, useInsecure bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TemplateAndUpdateServiceMonitorDeployment", url, blackBoxExporterNamespace, namespacedName, clusterID, hcp)
+	ret := m.ctrl.Call(m, "TemplateAndUpdateServiceMonitorDeployment", url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TemplateAndUpdateServiceMonitorDeployment indicates an expected call of TemplateAndUpdateServiceMonitorDeployment.
-func (mr *MockServiceMonitorHandlerMockRecorder) TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace, namespacedName, clusterID, hcp interface{}) *gomock.Call {
+func (mr *MockServiceMonitorHandlerMockRecorder) TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateAndUpdateServiceMonitorDeployment", reflect.TypeOf((*MockServiceMonitorHandler)(nil).TemplateAndUpdateServiceMonitorDeployment), url, blackBoxExporterNamespace, namespacedName, clusterID, hcp)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateAndUpdateServiceMonitorDeployment", reflect.TypeOf((*MockServiceMonitorHandler)(nil).TemplateAndUpdateServiceMonitorDeployment), url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure)
 }
 
 // UpdateServiceMonitorDeployment mocks base method.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-21000

---

Modifies the routemonitor logic to enable monitoring of kube-apiservers in hypershift using internal routes