### PR TITLE
Add hostedcontrolplane controller

### DIFF
--- a/api/v1alpha1/routemonitor_types.go
+++ b/api/v1alpha1/routemonitor_types.go
@@ -38,7 +38,20 @@ type RouteMonitorSpec struct {
 	// InsecureSkipTLSVerify indicates that the blackbox exporter module used to probe this route
 	// should *not* use https
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=monitoring.coreos.com;monitoring.rhobs
+	// +kubebuilder:default=monitoring.coreos.com
+
+	// ServiceMonitorType dictates the type of ServiceMonitor the RouteMonitor should create
+	ServiceMonitorType string `json:"serviceMonitorType,omitempty"`
 }
+
+const (
+	// The following values should match the kubebuilder-enumerated values for serviceMonitorType above
+	ServiceMonitorTypeCoreOS = "monitoring.coreos.com"
+	ServiceMonitorTypeRHOBS  = "monitoring.rhobs"
+)
 
 // RouteMonitorRouteSpec references the observed Route resource
 type RouteMonitorRouteSpec struct {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -62,7 +62,7 @@ rules:
 - apiGroups:
   - hypershift.openshift.io
   resources:
-  - hostedclusters
+  - hostedcontrolplanes
   verbs:
   - get
   - list
@@ -99,9 +99,22 @@ rules:
   - update
   - watch
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - create
+- apiGroups:
   - monitoring.openshift.io
   resources:
   - clusterurlmonitors
+  - clusterurlmonitors/finalizers
   verbs:
   - create
   - delete
@@ -122,6 +135,7 @@ rules:
   - monitoring.openshift.io
   resources:
   - routemonitors
+  - routemonitors/finalizers
   verbs:
   - create
   - delete
@@ -150,10 +164,58 @@ rules:
   - update
   - watch
 - apiGroups:
-  - route.openshift.io
+  - monitoring.rhobs
   resources:
-  - routes
+  - servicemonitors/finalizers
   verbs:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
+  - create
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedcontrolplanes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedcontrolplanes/finalizers
+  - hostedcontrolplanes/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - create

--- a/controllers/clusterurlmonitor/clusterurlmonitor.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor.go
@@ -23,7 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	monitoringv1alpha1 "github.com/openshift/route-monitor-operator/api/v1alpha1"
 	"github.com/openshift/route-monitor-operator/controllers"
@@ -32,6 +34,7 @@ import (
 	reconcileCommon "github.com/openshift/route-monitor-operator/pkg/reconcile"
 	"github.com/openshift/route-monitor-operator/pkg/servicemonitor"
 	utilreconcile "github.com/openshift/route-monitor-operator/pkg/util/reconcile"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 // ClusterUrlMonitorReconciler reconciles a ClusterUrlMonitor object
@@ -150,5 +153,12 @@ func (r *ClusterUrlMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 func (r *ClusterUrlMonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&monitoringv1alpha1.ClusterUrlMonitor{}).
+		Watches(
+			&source.Kind{Type: &monitoringv1.ServiceMonitor{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &monitoringv1alpha1.ClusterUrlMonitor{},
+				IsController: true,
+			},
+		).
 		Complete(r)
 }

--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
@@ -123,7 +123,8 @@ func (s *ClusterUrlMonitorReconciler) EnsureServiceMonitorExists(clusterUrlMonit
 		}
 	}
 
-	if err := s.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(clusterUrl, s.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, isHCP, false); err != nil {
+	owner := metav1.NewControllerRef(&clusterUrlMonitor.ObjectMeta, clusterUrlMonitor.GroupVersionKind())
+	if err := s.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(clusterUrl, s.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, isHCP, false, owner); err != nil {
 		return utilreconcile.RequeueReconcileWith(err)
 	}
 

--- a/controllers/clusterurlmonitor/clusterurlmonitor_test.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Clusterurlmonitor", func() {
 		When("the ServiceMonitor doesn't exist", func() {
 			BeforeEach(func() {
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(1) // fetching domain
-				mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockBlackBoxExporter.EXPECT().GetBlackBoxExporterNamespace().Times(1).Return("")
 				ns := types.NamespacedName{Name: clusterUrlMonitor.Name, Namespace: clusterUrlMonitor.Namespace}
 				mockCommon.EXPECT().GetOSDClusterID().Times(1)

--- a/controllers/hostedcontrolplane/hostedcontrolplane.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane.go
@@ -1,0 +1,316 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostedcontrolplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/hypershift/api/v1beta1"
+	"github.com/openshift/route-monitor-operator/api/v1alpha1"
+	"github.com/openshift/route-monitor-operator/pkg/util/finalizer"
+	utilreconcile "github.com/openshift/route-monitor-operator/pkg/util/reconcile"
+
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	// hostedcontrolplaneFinalizer defines the finalizer used by this controller's objects
+	hostedcontrolplaneFinalizer = "hostedcontrolplane.routemonitoroperator.monitoring.openshift.io/finalizer"
+
+	// watchResourceLabel is a label key indicating which objects this controller should reconcile against
+	watchResourceLabel = "hostedcontrolplane.routemonitoroperator.monitoring.openshift.io/managed"
+)
+
+var logger logr.Logger = ctrl.Log.WithName("controllers").WithName("HostedControlPlane")
+
+// HostedControlPlaneReconciler reconciles a HostedControlPlane object
+type HostedControlPlaneReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	// monitoringNamespace dictates which namespace we should deploy routeMonitors to
+	monitoringNamespace string
+}
+
+// NewHostedControlPlaneReconciler creates a HostedControlPlaneReconciler
+func NewHostedControlPlaneReconciler(mgr manager.Manager, monitoringNamespace string) *HostedControlPlaneReconciler {
+	return &HostedControlPlaneReconciler{
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		monitoringNamespace: monitoringNamespace,
+	}
+}
+
+//+kubebuilder:rbac:groups=openshift.io,resources=hostedcontrolplanes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=openshift.io,resources=hostedcontrolplanes/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=openshift.io,resources=hostedcontrolplanes/finalizers,verbs=update
+
+// Reconcile responds to events against watched objects
+func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logger.WithName("Reconcile").WithValues("name", req.Name, "namespace", req.Namespace)
+	log.Info("Reconciling HostedControlPlanes")
+	defer log.Info("Finished reconciling HostedControlPlane")
+
+	// Fetch the HostedControlPlane instance
+	hostedcontrolplane := &v1beta1.HostedControlPlane{}
+	err := r.Client.Get(ctx, req.NamespacedName, hostedcontrolplane)
+	if err != nil {
+		if kerr.IsNotFound(err) {
+			log.Info("HostedControlPlane not found, assumed deleted")
+			return utilreconcile.RequeueWith(nil)
+		}
+		log.Error(err, "unable to fetch HostedControlPlane")
+		return utilreconcile.RequeueWith(err)
+	}
+
+	// If the HostedControlPlane is marked for deletion, clean up
+	shouldDelete := finalizer.WasDeleteRequested(hostedcontrolplane)
+	if shouldDelete {
+		err := r.finalizeHostedControlPlane(ctx, log, hostedcontrolplane)
+		if err != nil {
+			log.Error(err, "failed to finalize HostedControlPlane")
+			return utilreconcile.RequeueWith(err)
+		}
+		finalizer.Remove(hostedcontrolplane, hostedcontrolplaneFinalizer)
+		err = r.Client.Update(ctx, hostedcontrolplane)
+		return utilreconcile.RequeueWith(nil)
+	}
+
+	if !finalizer.Contains(hostedcontrolplane.Finalizers, hostedcontrolplaneFinalizer) {
+		finalizer.Add(hostedcontrolplane, hostedcontrolplaneFinalizer)
+		err := r.Client.Update(ctx, hostedcontrolplane)
+		if err != nil {
+			return utilreconcile.RequeueWith(err)
+		}
+	}
+
+	// Check if the HostedControlPlane is ready
+	if !hostedcontrolplane.Status.Ready {
+		log.Info("skipped deploying monitoring objects: HostedControlPlane not ready")
+		utilreconcile.RequeueWith(nil)
+	}
+
+	log.Info("Deploying internal monitoring objects")
+	err = r.deployInternalMonitoringObjects(ctx, log, hostedcontrolplane)
+	if err != nil {
+		log.Error(err, "failed to deploy internal monitoring components")
+		return utilreconcile.RequeueWith(err)
+	}
+
+	return ctrl.Result{}, err
+}
+
+// deployInternalMonitoringObjects creates or updates the objects needed to monitor the kube-apiserver using cluster-internal routes
+func (r *HostedControlPlaneReconciler) deployInternalMonitoringObjects(ctx context.Context, log logr.Logger, hostedcontrolplane *v1beta1.HostedControlPlane) error {
+	// Create or update route object
+	expectedRoute := r.buildInternalMonitoringRoute(hostedcontrolplane)
+	err := r.Client.Create(ctx, &expectedRoute)
+	if err != nil {
+		if !kerr.IsAlreadyExists(err) {
+			return err
+		}
+		// Object already exists: update it
+		actualRoute := routev1.Route{}
+		err := r.Client.Get(ctx, types.NamespacedName{Name: expectedRoute.Name, Namespace: expectedRoute.Namespace}, &actualRoute)
+		if err != nil {
+			return err
+		}
+		expectedRoute.ObjectMeta = buildMetadataForUpdate(expectedRoute.ObjectMeta, actualRoute.ObjectMeta)
+		err = r.Client.Update(ctx, &expectedRoute)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create or update RouteMonitor object
+	expectedRouteMonitor := r.buildInternalMonitoringRouteMonitor(expectedRoute, hostedcontrolplane)
+	err = r.Client.Create(ctx, &expectedRouteMonitor)
+	if err != nil {
+		if !kerr.IsAlreadyExists(err) {
+			return err
+		}
+		// Object already exists: update it
+		actualRouteMonitor := v1alpha1.RouteMonitor{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: expectedRouteMonitor.Name, Namespace: expectedRouteMonitor.Namespace}, &actualRouteMonitor)
+		if err != nil {
+			return err
+		}
+		expectedRouteMonitor.ObjectMeta = buildMetadataForUpdate(expectedRouteMonitor.ObjectMeta, actualRouteMonitor.ObjectMeta)
+		err = r.Client.Update(ctx, &expectedRoute)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// buildMetadataForUpdate is a helper function to generate valid metadata for an Update request by combining the expected object's Metadata and the actual (on-cluster) object's Metadata
+func buildMetadataForUpdate(expected, actual metav1.ObjectMeta) metav1.ObjectMeta {
+	actual.Labels = expected.Labels
+	actual.OwnerReferences = expected.OwnerReferences
+	return actual
+}
+
+// buildInternalMonitoringRoute constructs the Route needed to monitor a HostedControlPlane's kube-apiserver via cluster-internal routes
+func (r *HostedControlPlaneReconciler) buildInternalMonitoringRoute(hostedcontrolplane *v1beta1.HostedControlPlane) routev1.Route {
+	weight := int32(100)
+	route := routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            fmt.Sprintf("%s-kube-apiserver-monitoring", hostedcontrolplane.Name),
+			Namespace:       hostedcontrolplane.Namespace,
+			OwnerReferences: r.buildOwnerReferences(hostedcontrolplane),
+			Labels: map[string]string{
+				watchResourceLabel: "true",
+			},
+		},
+		Spec: routev1.RouteSpec{
+			Host: fmt.Sprintf("kube-apiserver.%s.svc.cluster.local", hostedcontrolplane.Namespace),
+			TLS: &routev1.TLSConfig{
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+				Termination:                   routev1.TLSTerminationPassthrough,
+			},
+			To: routev1.RouteTargetReference{
+				Kind:   "Service",
+				Name:   "kube-apiserver",
+				Weight: &weight,
+			},
+			WildcardPolicy: routev1.WildcardPolicyNone,
+		},
+	}
+
+	return route
+}
+
+// buildInternalMonitoringRouteMonitor constructs the expected RouteMonitor needed to probe a HostedControlPlane's kube-apiserver using cluster-internal routes
+func (r *HostedControlPlaneReconciler) buildInternalMonitoringRouteMonitor(route routev1.Route, hostedcontrolplane *v1beta1.HostedControlPlane) v1alpha1.RouteMonitor {
+	routemonitor := v1alpha1.RouteMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            route.Name,
+			Namespace:       route.Namespace,
+			OwnerReferences: r.buildOwnerReferences(hostedcontrolplane),
+			Labels: map[string]string{
+				watchResourceLabel: "true",
+			},
+		},
+		Spec: v1alpha1.RouteMonitorSpec{
+			Route: v1alpha1.RouteMonitorRouteSpec{
+				Name:      route.Name,
+				Namespace: route.Namespace,
+				Port:      6443,
+				Suffix:    "/livez",
+			},
+			SkipPrometheusRule: false,
+			Slo: v1alpha1.SloSpec{
+				TargetAvailabilityPercent: "99.5",
+			},
+			InsecureSkipTLSVerify: true,
+			ServiceMonitorType:    v1alpha1.ServiceMonitorTypeRHOBS,
+		},
+	}
+	return routemonitor
+}
+
+// buildOwnerReferences generates a set OwnerReferences indicating the HostedControlPlane is the owner+controller of the object. This is used
+// to trigger reconciles against non-HCP objects (ie - the route & routemonitor generated by this controller)
+func (r *HostedControlPlaneReconciler) buildOwnerReferences(hostedcontrolplane *v1beta1.HostedControlPlane) []metav1.OwnerReference {
+	return []metav1.OwnerReference{*metav1.NewControllerRef(&hostedcontrolplane.ObjectMeta, hostedcontrolplane.GroupVersionKind())}
+}
+
+// finalizeHostedControlPlane cleans up HostedControlPlane-related objects managed by the HostedControlPlaneReconciler
+func (r *HostedControlPlaneReconciler) finalizeHostedControlPlane(ctx context.Context, log logr.Logger, hostedcontrolplane *v1beta1.HostedControlPlane) error {
+	r.deleteInternalMonitoringObjects(ctx, log, hostedcontrolplane)
+	return nil
+}
+
+// deleteInternalMonitoringObjects removes the internal monitoring objects for the provided HostedControlPlane
+func (r *HostedControlPlaneReconciler) deleteInternalMonitoringObjects(ctx context.Context, log logr.Logger, hostedcontrolplane *v1beta1.HostedControlPlane) error {
+	// Delete Route
+	expectedRoute := r.buildInternalMonitoringRoute(hostedcontrolplane)
+	err := r.Client.Delete(ctx, &expectedRoute)
+	if err != nil {
+		if !kerr.IsNotFound(err) {
+			return err
+		}
+		log.Info(fmt.Sprintf("Skipped deleting Route %s/%s: already deleted", expectedRoute.Namespace, expectedRoute.Name))
+	}
+
+	// Delete routemonitor
+	expectedRouteMonitor := r.buildInternalMonitoringRouteMonitor(expectedRoute, hostedcontrolplane)
+	err = r.Client.Delete(ctx, &expectedRouteMonitor)
+	if err != nil {
+		if !kerr.IsNotFound(err) {
+			return err
+		}
+		log.Info(fmt.Sprintf("Skipped deleting RouteMonitor %s/%s: already deleted", expectedRoute.Namespace, expectedRoute.Name))
+	}
+
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	selector := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      watchResourceLabel,
+				Operator: metav1.LabelSelectorOpExists,
+			},
+		},
+	}
+	selectorPredicate, err := predicate.LabelSelectorPredicate(selector)
+	if err != nil {
+		return fmt.Errorf("failed to build label selector predicate for routes: %w", err)
+	}
+
+	// The following:
+	// - Reconciles against all HostedControlPlane objects
+	// - Additionally watches against route & routemonitor objects with the 'watchResourceLabel' present.
+	//   When these objects are modified, the HCP specified in the objects' .metadata.OwnerReferences is
+	//   reconciled
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1beta1.HostedControlPlane{}).
+		Watches(
+			&source.Kind{Type: &routev1.Route{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &v1beta1.HostedControlPlane{},
+				IsController: true,
+			},
+			builder.WithPredicates(selectorPredicate)).
+		Watches(
+			&source.Kind{Type: &v1alpha1.RouteMonitor{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &v1beta1.HostedControlPlane{},
+				IsController: true,
+			},
+			builder.WithPredicates(selectorPredicate)).
+		Complete(r)
+}

--- a/controllers/interfaces.go
+++ b/controllers/interfaces.go
@@ -7,6 +7,7 @@ import (
 	utilreconcile "github.com/openshift/route-monitor-operator/pkg/util/reconcile"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rhobsv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,7 +64,7 @@ type ServiceMonitorHandler interface {
 
 	// TemplateAndUpdateServiceMonitorDeployment will generate a template and then
 	// call UpdateServiceMonitorDeployment to ensure its current state matches the template.
-	TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, hcp bool, useInsecure bool) error
+	TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, hcp bool, useInsecure bool, owner *metav1.OwnerReference) error
 
 	// DeleteServiceMonitorDeployment deletes a ServiceMonitor refrenced by a namespaced name
 	DeleteServiceMonitorDeployment(serviceMonitorRef v1alpha1.NamespacedName, hcp bool) error

--- a/controllers/routemonitor/routemonitor.go
+++ b/controllers/routemonitor/routemonitor.go
@@ -28,10 +28,13 @@ import (
 	"github.com/openshift/route-monitor-operator/pkg/servicemonitor"
 	"github.com/openshift/route-monitor-operator/pkg/util/finalizer"
 	utilreconcile "github.com/openshift/route-monitor-operator/pkg/util/reconcile"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // RouteMonitorReconciler reconciles a RouteMonitor object
@@ -170,5 +173,12 @@ func (r *RouteMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *RouteMonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&monitoringv1alpha1.RouteMonitor{}).
+		Watches(
+			&source.Kind{Type: &monitoringv1.ServiceMonitor{}},
+			&handler.EnqueueRequestForOwner{
+				OwnerType:    &monitoringv1alpha1.RouteMonitor{},
+				IsController: true,
+			},
+		).
 		Complete(r)
 }

--- a/controllers/routemonitor/routemonitor_supplement.go
+++ b/controllers/routemonitor/routemonitor_supplement.go
@@ -14,6 +14,7 @@ import (
 	utilreconcile "github.com/openshift/route-monitor-operator/pkg/util/reconcile"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -77,13 +78,18 @@ func (r *RouteMonitorReconciler) EnsureServiceMonitorExists(routeMonitor v1alpha
 
 	// update ServiceMonitor if requiredctrl
 	namespacedName := types.NamespacedName{Name: routeMonitor.Name, Namespace: routeMonitor.Namespace}
-	isHCP := false
 	id, err := r.Common.GetOSDClusterID()
 	if err != nil {
 		return utilreconcile.RequeueReconcileWith(err)
 	}
 
-	if err := r.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(routeMonitor.Status.RouteURL, r.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, isHCP, routeMonitor.Spec.InsecureSkipTLSVerify); err != nil {
+	useRHOBS := false
+	if routeMonitor.Spec.ServiceMonitorType == v1alpha1.ServiceMonitorTypeRHOBS {
+		useRHOBS = true
+	}
+
+	owner := metav1.NewControllerRef(&routeMonitor.ObjectMeta, routeMonitor.GroupVersionKind())
+	if err := r.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(routeMonitor.Status.RouteURL, r.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, useRHOBS, routeMonitor.Spec.InsecureSkipTLSVerify, owner); err != nil {
 		return utilreconcile.RequeueReconcileWith(err)
 	}
 	// update ServiceMonitorRef if required

--- a/controllers/routemonitor/routemonitor_test.go
+++ b/controllers/routemonitor/routemonitor_test.go
@@ -778,7 +778,7 @@ var _ = Describe("Routemonitor", func() {
 		Describe("It updates the ServiceMonitor targeting the blackbox Exporter Namespace", func() {
 			When("the update of the ServiceMonitor fails", func() {
 				BeforeEach(func() {
-					mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(consterror.CustomError)
+					mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(consterror.CustomError)
 					mockBlackboxExporter.EXPECT().GetBlackBoxExporterNamespace().Return("bla")
 					mockUtils.EXPECT().GetOSDClusterID().Return("test-cluster-id", nil)
 				})
@@ -789,7 +789,7 @@ var _ = Describe("Routemonitor", func() {
 			})
 			When("the update of the ServiceMonitor is successfull", func() {
 				BeforeEach(func() {
-					mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+					mockServiceMonitor.EXPECT().TemplateAndUpdateServiceMonitorDeployment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 					mockBlackboxExporter.EXPECT().GetBlackBoxExporterNamespace().Return("bla")
 					mockUtils.EXPECT().GetOSDClusterID().Return("test-cluster-id", nil)
 				})

--- a/deploy/crds/monitoring.openshift.io_routemonitors.yaml
+++ b/deploy/crds/monitoring.openshift.io_routemonitors.yaml
@@ -59,6 +59,14 @@ spec:
                       (/livez /readyz etc)
                     type: string
                 type: object
+              serviceMonitorType:
+                default: monitoring.coreos.com
+                description: ServiceMonitorType dictates the type of ServiceMonitor
+                  the RouteMonitor should create
+                enum:
+                - monitoring.coreos.com
+                - monitoring.rhobs
+                type: string
               skipPrometheusRule:
                 description: SkipPrometheusRule instructs the controller to skip the
                   creation of PrometheusRule CRs. One common use-case for is for alerts

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -64,7 +64,7 @@ rules:
   - apiGroups:
       - hypershift.openshift.io
     resources:
-      - hostedclusters
+      - hostedcontrolplanes
     verbs:
       - get
       - list
@@ -101,9 +101,22 @@ rules:
       - update
       - watch
   - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+      - create
+  - apiGroups:
       - monitoring.openshift.io
     resources:
       - clusterurlmonitors
+      - clusterurlmonitors/finalizers
     verbs:
       - create
       - delete
@@ -124,6 +137,7 @@ rules:
       - monitoring.openshift.io
     resources:
       - routemonitors
+      - routemonitors/finalizers
     verbs:
       - create
       - delete
@@ -152,10 +166,58 @@ rules:
       - update
       - watch
   - apiGroups:
-      - route.openshift.io
+      - monitoring.rhobs
     resources:
-      - routes
+      - servicemonitors/finalizers
     verbs:
       - get
       - list
       - watch
+      - update
+      - patch
+      - delete
+      - create
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - create
+      - delete
+      - update
+      - patch
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes/custom-host
+    verbs:
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - hypershift.openshift.io
+    resources:
+      - hostedcontrolplanes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - hypershift.openshift.io
+    resources:
+      - hostedcontrolplanes/finalizers
+      - hostedcontrolplanes/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+      - create

--- a/int/integration.go
+++ b/int/integration.go
@@ -92,7 +92,7 @@ func (i *Integration) RemoveClusterUrlMonitor(namespace, name string) error {
 		time.Sleep(1 * time.Second)
 	}
 	if t == maxRetries {
-		ginkgo.Fail("ClusterUrlMonitor didn't appear after %d seconds", maxRetries)
+		ginkgo.Fail("ClusterUrlMonitor wasn't removed after %d seconds", maxRetries)
 	}
 	return err
 }
@@ -122,7 +122,7 @@ func (i *Integration) RemoveRouteMonitor(namespace, name string) error {
 		time.Sleep(1 * time.Second)
 	}
 	if t == maxRetries {
-		ginkgo.Fail("RouteMonitor didn't appear after %d seconds", maxRetries)
+		ginkgo.Fail("RouteMonitor wasn't removed after %d seconds", maxRetries)
 	}
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	monitoringopenshiftiov1alpha1 "github.com/openshift/route-monitor-operator/api/v1alpha1"
 	monitoringv1alpha1 "github.com/openshift/route-monitor-operator/api/v1alpha1"
 	"github.com/openshift/route-monitor-operator/controllers/clusterurlmonitor"
+	"github.com/openshift/route-monitor-operator/controllers/hostedcontrolplane"
 	"github.com/openshift/route-monitor-operator/controllers/routemonitor"
 	rhobsv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
 	// +kubebuilder:scaffold:imports
@@ -130,6 +131,14 @@ func main() {
 	if err = clusterUrlMonitorReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "clusterUrlMonitorReconciler")
 		os.Exit(1)
+	}
+
+	if enablehypershift {
+		hostedControlPlaneReconciler := hostedcontrolplane.NewHostedControlPlaneReconciler(mgr, blackboxExporterNamespace)
+		if err = hostedControlPlaneReconciler.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "HostedCluster")
+			os.Exit(1)
+		}
 	}
 
 	// +kubebuilder:scaffold:builder

--- a/pkg/servicemonitor/servicemonitor.go
+++ b/pkg/servicemonitor/servicemonitor.go
@@ -33,7 +33,7 @@ const (
 	UrlLabelName         string = "probe_url"
 )
 
-func (u *ServiceMonitor) TemplateAndUpdateServiceMonitorDeployment(routeURL, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, isHCPMonitor bool, useInsecure bool) error {
+func (u *ServiceMonitor) TemplateAndUpdateServiceMonitorDeployment(routeURL, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, isHCPMonitor bool, useInsecure bool, owner *metav1.OwnerReference) error {
 	module := "http_2xx"
 	if useInsecure {
 		module = "insecure_http_2xx"
@@ -45,10 +45,10 @@ func (u *ServiceMonitor) TemplateAndUpdateServiceMonitorDeployment(routeURL, bla
 	}
 
 	if isHCPMonitor {
-		s := u.HyperShiftTemplateForServiceMonitorResource(routeURL, blackBoxExporterNamespace, params, namespacedName, clusterID)
+		s := u.HyperShiftTemplateForServiceMonitorResource(routeURL, blackBoxExporterNamespace, params, namespacedName, clusterID, owner)
 		return u.HypershiftUpdateServiceMonitorDeployment(s)
 	}
-	s := u.TemplateForServiceMonitorResource(routeURL, blackBoxExporterNamespace, params, namespacedName, clusterID)
+	s := u.TemplateForServiceMonitorResource(routeURL, blackBoxExporterNamespace, params, namespacedName, clusterID, owner)
 	return u.UpdateServiceMonitorDeployment(s)
 }
 
@@ -131,11 +131,12 @@ func (u *ServiceMonitor) DeleteServiceMonitorDeployment(serviceMonitorRef v1alph
 }
 
 // TemplateForServiceMonitorResource returns a ServiceMonitor
-func (u *ServiceMonitor) TemplateForServiceMonitorResource(routeURL, blackBoxExporterNamespace string, params map[string][]string, namespacedName types.NamespacedName, clusterID string) monitoringv1.ServiceMonitor {
+func (u *ServiceMonitor) TemplateForServiceMonitorResource(routeURL, blackBoxExporterNamespace string, params map[string][]string, namespacedName types.NamespacedName, clusterID string, owner *metav1.OwnerReference) monitoringv1.ServiceMonitor {
 	return monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespacedName.Name,
-			Namespace: namespacedName.Namespace,
+			Name:            namespacedName.Name,
+			Namespace:       namespacedName.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*owner},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{
@@ -172,11 +173,12 @@ func (u *ServiceMonitor) TemplateForServiceMonitorResource(routeURL, blackBoxExp
 }
 
 // HyperShiftTemplateForServiceMonitorResource returns a ServiceMonitor for Hypershift
-func (u *ServiceMonitor) HyperShiftTemplateForServiceMonitorResource(routeURL, blackBoxExporterNamespace string, params map[string][]string, namespacedName types.NamespacedName, clusterID string) rhobsv1.ServiceMonitor {
+func (u *ServiceMonitor) HyperShiftTemplateForServiceMonitorResource(routeURL, blackBoxExporterNamespace string, params map[string][]string, namespacedName types.NamespacedName, clusterID string, owner *metav1.OwnerReference) rhobsv1.ServiceMonitor {
 	return rhobsv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespacedName.Name,
-			Namespace: namespacedName.Namespace,
+			Name:            namespacedName.Name,
+			Namespace:       namespacedName.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*owner},
 		},
 		Spec: rhobsv1.ServiceMonitorSpec{
 			Endpoints: []rhobsv1.Endpoint{

--- a/pkg/util/finalizer/finalizer.go
+++ b/pkg/util/finalizer/finalizer.go
@@ -2,7 +2,6 @@ package finalizer
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -29,11 +28,11 @@ func Add(object metav1.Object, finalizer string) {
 }
 
 // WasDeleteRequested verifies if the resource was requested for deletion
-func WasDeleteRequested(o v1.Object) bool {
+func WasDeleteRequested(o metav1.Object) bool {
 	return o.GetDeletionTimestamp() != nil
 }
 
 // HasFinalizer verifies if a finalizer is placed on the resource
-func HasFinalizer(o v1.Object, finalizerKey string) bool {
+func HasFinalizer(o metav1.Object, finalizerKey string) bool {
 	return Contains(o.GetFinalizers(), finalizerKey)
 }

--- a/pkg/util/test/generated/mocks/controllers/interfaces.go
+++ b/pkg/util/test/generated/mocks/controllers/interfaces.go
@@ -241,17 +241,17 @@ func (mr *MockServiceMonitorHandlerMockRecorder) HypershiftUpdateServiceMonitorD
 }
 
 // TemplateAndUpdateServiceMonitorDeployment mocks base method.
-func (m *MockServiceMonitorHandler) TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, hcp, useInsecure bool) error {
+func (m *MockServiceMonitorHandler) TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace string, namespacedName types.NamespacedName, clusterID string, hcp, useInsecure bool, owner *v11.OwnerReference) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TemplateAndUpdateServiceMonitorDeployment", url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure)
+	ret := m.ctrl.Call(m, "TemplateAndUpdateServiceMonitorDeployment", url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure, owner)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TemplateAndUpdateServiceMonitorDeployment indicates an expected call of TemplateAndUpdateServiceMonitorDeployment.
-func (mr *MockServiceMonitorHandlerMockRecorder) TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure interface{}) *gomock.Call {
+func (mr *MockServiceMonitorHandlerMockRecorder) TemplateAndUpdateServiceMonitorDeployment(url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateAndUpdateServiceMonitorDeployment", reflect.TypeOf((*MockServiceMonitorHandler)(nil).TemplateAndUpdateServiceMonitorDeployment), url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateAndUpdateServiceMonitorDeployment", reflect.TypeOf((*MockServiceMonitorHandler)(nil).TemplateAndUpdateServiceMonitorDeployment), url, blackBoxExporterNamespace, namespacedName, clusterID, hcp, useInsecure, owner)
 }
 
 // UpdateServiceMonitorDeployment mocks base method.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-21000

---

Adds an initial implementation of the `hostedcontrolplane` controller. This controller watches `hostedcontrolplane` objects and creates a `route` + `routemonitor` pair in each HCP's namespace to monitor a hosted cluster's  kube-apiserver using cluster-internal endpoints.


