### PR TITLE
Revert #268; setup hostedcontrolplane controller if CRD is present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ endif
 
 .PHONY: package
 package: kubectl-package
-	$(CONTAINER_ENGINE) run --rm -v ${PWD}:/workdir quay.io/app-sre/yq:4 '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)" | .spec.template.spec.containers[0].args = .spec.template.spec.containers[0].args + ["--enable-hypershift=true"]' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
+	$(CONTAINER_ENGINE) run --rm -v ${PWD}:/workdir quay.io/app-sre/yq:4 '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
 	$(CONTAINER_ENGINE) login -u $(QUAY_USER) -p $(QUAY_TOKEN) quay.io
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:$(OPERATOR_IMAGE_TAG) --push packaging/
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:latest --push packaging/

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -219,3 +219,9 @@ rules:
   - patch
   - delete
   - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -221,3 +221,9 @@ rules:
       - patch
       - delete
       - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get

--- a/main.go
+++ b/main.go
@@ -17,14 +17,19 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -58,6 +63,7 @@ func init() {
 	utilruntime.Must(monitoringopenshiftiov1alpha1.AddToScheme(scheme))
 	utilruntime.Must(hypershiftv1beta1.AddToScheme(scheme))
 	utilruntime.Must(rhobsv1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -133,10 +139,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if enablehypershift {
+	enableHCP, err := shouldEnableHCP(mgr)
+	if err != nil {
+		setupLog.Error(err, "failed to determine whether HCP controller should be enabled", "controller", "HostedControlPlane")
+	}
+	if enableHCP {
 		hostedControlPlaneReconciler := hostedcontrolplane.NewHostedControlPlaneReconciler(mgr, blackboxExporterNamespace)
 		if err = hostedControlPlaneReconciler.SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "HostedCluster")
+			setupLog.Error(err, "unable to create controller", "controller", "HostedControlPlane")
 			os.Exit(1)
 		}
 	}
@@ -160,4 +170,24 @@ func main() {
 
 	setupLog.V(1).Info("`mgr.Start` is blocking:",
 		"so this message (or anything that resides after it) won't execute until teardown", nil)
+}
+
+// shouldEnableHCP checks for the existence of the 'hostedcontrolplane' CRD to determine whether this controller should be enabled or not:
+//  - if it exists, enable the HCP controller
+//  - if we get an error unrelated to it's existence (ie - kubeapiserver is down) return the error
+//  - if we get an error due to it not existing, disable the HCP controller
+func shouldEnableHCP(mgr ctrl.Manager) (bool, error) {
+	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		return false, err
+	}
+
+	err = c.Get(context.TODO(), types.NamespacedName{Name: "hostedcontrolplanes.hypershift.openshift.io"}, &apiextensionsv1.CustomResourceDefinition{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-21000

---

Reverts the change from #268 and re-implements the intention of only enabling the `hostedcontrolplane` controller when the relevant CRD is actually present on the cluster.