### PR TITLE
Deploy RHOBS prometheusrules when using a RHOBS servicemonitors

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -77,6 +77,7 @@ rules:
   - watch
 - apiGroups:
   - monitoring.coreos.com
+  - monitoring.rhobs
   resources:
   - prometheusrules
   verbs:

--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
@@ -69,8 +69,8 @@ func (s *ClusterUrlMonitorReconciler) EnsurePrometheusRuleExists(clusterUrlMonit
 	}
 
 	namespacedName := types.NamespacedName{Namespace: clusterUrlMonitor.Namespace, Name: clusterUrlMonitor.Name}
-	template := alert.TemplateForPrometheusRuleResource(clusterUrl, parsedSlo, namespacedName)
-	err = s.Prom.UpdatePrometheusRuleDeployment(template)
+	template := alert.TemplateForCoreOSPrometheusRuleResource(clusterUrl, parsedSlo, namespacedName)
+	err = s.Prom.UpdateCoreOSPrometheusRuleDeployment(template)
 	if err != nil {
 		return utilreconcile.RequeueReconcileWith(err)
 	}

--- a/controllers/clusterurlmonitor/clusterurlmonitor_test.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Clusterurlmonitor", func() {
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockCommon.EXPECT().ParseMonitorSLOSpecs(gomock.Any(), clusterUrlMonitor.Spec.Slo).Times(1).Return("99.5", nil)
 				mockCommon.EXPECT().SetErrorStatus(&clusterUrlMonitor.Status.ErrorStatus, nil)
-				mockPrometheusRule.EXPECT().UpdatePrometheusRuleDeployment(gomock.Any()).Times(1)
+				mockPrometheusRule.EXPECT().UpdateCoreOSPrometheusRuleDeployment(gomock.Any()).Times(1)
 				mockCommon.EXPECT().SetResourceReference(&clusterUrlMonitor.Status.PrometheusRuleRef, gomock.Any()).Times(1).Return(false, nil)
 			})
 			It("doesn't update the clusterUrlMonitor reference and continues reconciling", func() {
@@ -143,7 +143,7 @@ var _ = Describe("Clusterurlmonitor", func() {
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockCommon.EXPECT().ParseMonitorSLOSpecs(gomock.Any(), clusterUrlMonitor.Spec.Slo).Times(1).Return("99.5", nil)
 				mockCommon.EXPECT().SetErrorStatus(&clusterUrlMonitor.Status.ErrorStatus, nil)
-				mockPrometheusRule.EXPECT().UpdatePrometheusRuleDeployment(gomock.Any()).Times(1)
+				mockPrometheusRule.EXPECT().UpdateCoreOSPrometheusRuleDeployment(gomock.Any()).Times(1)
 				ns := types.NamespacedName{Name: clusterUrlMonitor.Name, Namespace: clusterUrlMonitor.Namespace}
 				mockCommon.EXPECT().SetResourceReference(&clusterUrlMonitor.Status.PrometheusRuleRef, ns).Times(1).Return(true, nil)
 				mockCommon.EXPECT().UpdateMonitorResourceStatus(&clusterUrlMonitor).Times(1).Return(utilreconcile.StopOperation(), nil)

--- a/controllers/interfaces.go
+++ b/controllers/interfaces.go
@@ -75,10 +75,15 @@ type ServiceMonitorHandler interface {
 }
 
 type PrometheusRuleHandler interface {
-	// UpdatePrometheusRuleDeployment ensures that a PrometheusRule deployment according
+	// UpdateCoreOSPrometheusRuleDeployment ensures that a PrometheusRule.monitoring.coreos.com deployment according
 	// to the template exists. If none exists, it will create a new one.
 	// If the template changed, it will update the existing deployment
-	UpdatePrometheusRuleDeployment(template monitoringv1.PrometheusRule) error
+	UpdateCoreOSPrometheusRuleDeployment(template monitoringv1.PrometheusRule) error
+
+	// UpdateRHOBSPrometheusRuleDeployment ensures that a PrometheusRule.monitoring.rhobs deployment according
+	// to the template exists. If none exists, it will create a new one.
+	// If the template changed, it will update the existing deployment
+	UpdateRHOBSPrometheusRuleDeployment(template rhobsv1.PrometheusRule) error
 
 	// DeletePrometheusRuleDeployment deletes a PrometheusRule refrenced by a namespaced name
 	DeletePrometheusRuleDeployment(prometheusRuleRef v1alpha1.NamespacedName) error

--- a/controllers/routemonitor/routemonitor_test.go
+++ b/controllers/routemonitor/routemonitor_test.go
@@ -718,7 +718,7 @@ var _ = Describe("Routemonitor", func() {
 			})
 			When("the update the PrometheusRule failed", func() {
 				BeforeEach(func() {
-					mockPrometheusRule.EXPECT().UpdatePrometheusRuleDeployment(gomock.Any()).Return(consterror.CustomError)
+					mockPrometheusRule.EXPECT().UpdateCoreOSPrometheusRuleDeployment(gomock.Any()).Return(consterror.CustomError)
 				})
 				It("requeues with the error", func() {
 					Expect(err).To(Equal(consterror.CustomError))
@@ -727,7 +727,7 @@ var _ = Describe("Routemonitor", func() {
 			})
 			When("the update of the PrometheusRule succeded", func() {
 				BeforeEach(func() {
-					mockPrometheusRule.EXPECT().UpdatePrometheusRuleDeployment(gomock.Any())
+					mockPrometheusRule.EXPECT().UpdateCoreOSPrometheusRuleDeployment(gomock.Any())
 				})
 				When("a new PrometheusRule was created", func() {
 					BeforeEach(func() {

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -79,6 +79,7 @@ rules:
       - watch
   - apiGroups:
       - monitoring.coreos.com
+      - monitoring.rhobs
     resources:
       - prometheusrules
     verbs:

--- a/int/integration.go
+++ b/int/integration.go
@@ -226,7 +226,7 @@ func (i *Integration) RouteMonitorWaitForPrometheusRuleCorrectSLO(name types.Nam
 		return err
 	}
 
-	template := alert.TemplateForPrometheusRuleResource(routeMonitor.Status.RouteURL, targetSlo, name)
+	template := alert.TemplateForCoreOSPrometheusRuleResource(routeMonitor.Status.RouteURL, targetSlo, name)
 	t := 0
 	for ; t < seconds; t++ {
 		err := i.Client.Get(context.TODO(), name, &prometheusRule)
@@ -263,7 +263,7 @@ func (i *Integration) ClusterUrlMonitorWaitForPrometheusRuleCorrectSLO(name type
 		return err
 	}
 
-	template := alert.TemplateForPrometheusRuleResource(expectedUrl, targetSlo, name)
+	template := alert.TemplateForCoreOSPrometheusRuleResource(expectedUrl, targetSlo, name)
 	t := 0
 	for ; t < seconds; t++ {
 		err := i.Client.Get(context.TODO(), name, &prometheusRule)

--- a/main.go
+++ b/main.go
@@ -173,9 +173,9 @@ func main() {
 }
 
 // shouldEnableHCP checks for the existence of the 'hostedcontrolplane' CRD to determine whether this controller should be enabled or not:
-//  - if it exists, enable the HCP controller
-//  - if we get an error unrelated to it's existence (ie - kubeapiserver is down) return the error
-//  - if we get an error due to it not existing, disable the HCP controller
+//   - if it exists, enable the HCP controller
+//   - if we get an error unrelated to it's existence (ie - kubeapiserver is down) return the error
+//   - if we get an error due to it not existing, disable the HCP controller
 func shouldEnableHCP(mgr ctrl.Manager) (bool, error) {
 	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {

--- a/pkg/alert/prometheusrule.go
+++ b/pkg/alert/prometheusrule.go
@@ -12,6 +12,7 @@ import (
 	util "github.com/openshift/route-monitor-operator/pkg/reconcile"
 	"github.com/openshift/route-monitor-operator/pkg/servicemonitor"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	rhobsv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -35,9 +36,29 @@ func NewPrometheusRule(ctx context.Context, c client.Client) *PrometheusRule {
 }
 
 // Creates or Updates PrometheusRule Deployment according to the template
-func (u *PrometheusRule) UpdatePrometheusRuleDeployment(template monitoringv1.PrometheusRule) error {
+func (u *PrometheusRule) UpdateCoreOSPrometheusRuleDeployment(template monitoringv1.PrometheusRule) error {
 	namespacedName := types.NamespacedName{Name: template.Name, Namespace: template.Namespace}
 	deployedPrometheusRule := &monitoringv1.PrometheusRule{}
+	err := u.Client.Get(u.Ctx, namespacedName, deployedPrometheusRule)
+	if err != nil {
+		// No similar Prometheus Rule exists
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+		return u.Client.Create(u.Ctx, &template)
+	}
+	if !u.Comparer.DeepEqual(template.Spec, deployedPrometheusRule.Spec) {
+		// Update existing PrometheuesRule for the case that the template changed
+		deployedPrometheusRule.Spec = template.Spec
+		return u.Client.Update(u.Ctx, deployedPrometheusRule)
+	}
+	return nil
+}
+
+// Creates or Updates PrometheusRule Deployment according to the template
+func (u *PrometheusRule) UpdateRHOBSPrometheusRuleDeployment(template rhobsv1.PrometheusRule) error {
+	namespacedName := types.NamespacedName{Name: template.Name, Namespace: template.Namespace}
+	deployedPrometheusRule := &rhobsv1.PrometheusRule{}
 	err := u.Client.Get(u.Ctx, namespacedName, deployedPrometheusRule)
 	if err != nil {
 		// No similar Prometheus Rule exists
@@ -104,8 +125,8 @@ func sufficientProbes(windowSize, label string) string {
 	return rule
 }
 
-// render creates a monitoring rule for the defined multiwindow multi-burn rate alert
-func (r *multiWindowMultiBurnAlertRule) render(url string, percent string, namespacedName types.NamespacedName) monitoringv1.Rule {
+// renderCoreOS creates a monitoring.coreos.com rule for the defined multiwindow multi-burn rate alert
+func (r *multiWindowMultiBurnAlertRule) renderCoreOS(url string, percent string, namespacedName types.NamespacedName) monitoringv1.Rule {
 	labelSelector := fmt.Sprintf(`%s="%s"`, servicemonitor.UrlLabelName, url)
 
 	alertString := "" +
@@ -128,6 +149,30 @@ func (r *multiWindowMultiBurnAlertRule) render(url string, percent string, names
 	}
 }
 
+// renderRHOBS creates a monitoring.rhobs rule for the defined multiwindow multi-burn rate alert
+func (r *multiWindowMultiBurnAlertRule) renderRHOBS(url string, percent string, namespacedName types.NamespacedName) rhobsv1.Rule {
+	labelSelector := fmt.Sprintf(`%s="%s"`, servicemonitor.UrlLabelName, url)
+
+	alertString := "" +
+		alertThreshold(r.shortWindow, percent, labelSelector, r.burnRate) +
+		" and " +
+		sufficientProbes(r.shortWindow, labelSelector) +
+		"\nand\n" +
+		alertThreshold(r.longWindow, percent, labelSelector, r.burnRate) +
+		" and " +
+		sufficientProbes(r.longWindow, labelSelector)
+
+	return rhobsv1.Rule{
+		Alert:  namespacedName.Name + "-ErrorBudgetBurn",
+		Expr:   intstr.FromString(alertString),
+		Labels: r.renderLabels(url, namespacedName.Namespace),
+		Annotations: map[string]string{
+			"message": fmt.Sprintf("High error budget burn for %s (current value: {{ $value }})", url),
+		},
+		For: r.duration,
+	}
+}
+
 func (r *multiWindowMultiBurnAlertRule) renderLabels(url, namespace string) map[string]string {
 	return map[string]string{
 		servicemonitor.UrlLabelName: url,
@@ -138,8 +183,8 @@ func (r *multiWindowMultiBurnAlertRule) renderLabels(url, namespace string) map[
 	}
 }
 
-// TemplateForPrometheusRuleResource returns a PrometheusRule
-func TemplateForPrometheusRuleResource(url, percent string, namespacedName types.NamespacedName) monitoringv1.PrometheusRule {
+// TemplateForCoreOSPrometheusRuleResource returns a PrometheusRule
+func TemplateForCoreOSPrometheusRuleResource(url, percent string, namespacedName types.NamespacedName) monitoringv1.PrometheusRule {
 
 	rules := []monitoringv1.Rule{}
 	alertRules := []multiWindowMultiBurnAlertRule{
@@ -174,7 +219,7 @@ func TemplateForPrometheusRuleResource(url, percent string, namespacedName types
 	}
 
 	for _, alertrule := range alertRules { // Create all the alerts
-		rules = append(rules, alertrule.render(url, percent, namespacedName))
+		rules = append(rules, alertrule.renderCoreOS(url, percent, namespacedName))
 	}
 
 	resource := monitoringv1.PrometheusRule{
@@ -184,6 +229,62 @@ func TemplateForPrometheusRuleResource(url, percent string, namespacedName types
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
+				{
+					Name:  "SLOs-probe",
+					Rules: rules,
+				},
+			},
+		},
+	}
+	return resource
+}
+
+// TemplateForRHOBSPrometheusRuleResource returns a PrometheusRule
+func TemplateForRHOBSPrometheusRuleResource(url, percent string, namespacedName types.NamespacedName) rhobsv1.PrometheusRule {
+
+	rules := []rhobsv1.Rule{}
+	alertRules := []multiWindowMultiBurnAlertRule{
+		{
+			duration:    "2m",
+			severity:    "critical",
+			longWindow:  "1h",
+			shortWindow: "5m",
+			burnRate:    "14.40",
+		},
+		{
+			duration:    "15m",
+			severity:    "critical",
+			longWindow:  "6h",
+			shortWindow: "30m",
+			burnRate:    "6",
+		},
+		{
+			duration:    "1h",
+			severity:    "warning",
+			longWindow:  "1d",
+			shortWindow: "2h",
+			burnRate:    "3",
+		},
+		{
+			duration:    "3h",
+			severity:    "warning",
+			longWindow:  "3d",
+			shortWindow: "6h",
+			burnRate:    "1",
+		},
+	}
+
+	for _, alertrule := range alertRules { // Create all the alerts
+		rules = append(rules, alertrule.renderRHOBS(url, percent, namespacedName))
+	}
+
+	resource := rhobsv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namespacedName.Name,
+			Namespace: namespacedName.Namespace,
+		},
+		Spec: rhobsv1.PrometheusRuleSpec{
+			Groups: []rhobsv1.RuleGroup{
 				{
 					Name:  "SLOs-probe",
 					Rules: rules,

--- a/pkg/alert/prometheusrule_test.go
+++ b/pkg/alert/prometheusrule_test.go
@@ -95,7 +95,7 @@ var _ = Describe("CR Deployment Handling", func() {
 			get.CalledTimes = 1
 		})
 		JustBeforeEach(func() {
-			err = pr.UpdatePrometheusRuleDeployment(prometheusRule)
+			err = pr.UpdateCoreOSPrometheusRuleDeployment(prometheusRule)
 		})
 		When("the Client failed to fetch existing deployments", func() {
 			BeforeEach(func() {

--- a/pkg/util/test/generated/mocks/controllers/interfaces.go
+++ b/pkg/util/test/generated/mocks/controllers/interfaces.go
@@ -305,18 +305,32 @@ func (mr *MockPrometheusRuleHandlerMockRecorder) DeletePrometheusRuleDeployment(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePrometheusRuleDeployment", reflect.TypeOf((*MockPrometheusRuleHandler)(nil).DeletePrometheusRuleDeployment), prometheusRuleRef)
 }
 
-// UpdatePrometheusRuleDeployment mocks base method.
-func (m *MockPrometheusRuleHandler) UpdatePrometheusRuleDeployment(template v1.PrometheusRule) error {
+// UpdateCoreOSPrometheusRuleDeployment mocks base method.
+func (m *MockPrometheusRuleHandler) UpdateCoreOSPrometheusRuleDeployment(template v1.PrometheusRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePrometheusRuleDeployment", template)
+	ret := m.ctrl.Call(m, "UpdateCoreOSPrometheusRuleDeployment", template)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdatePrometheusRuleDeployment indicates an expected call of UpdatePrometheusRuleDeployment.
-func (mr *MockPrometheusRuleHandlerMockRecorder) UpdatePrometheusRuleDeployment(template interface{}) *gomock.Call {
+// UpdateCoreOSPrometheusRuleDeployment indicates an expected call of UpdateCoreOSPrometheusRuleDeployment.
+func (mr *MockPrometheusRuleHandlerMockRecorder) UpdateCoreOSPrometheusRuleDeployment(template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePrometheusRuleDeployment", reflect.TypeOf((*MockPrometheusRuleHandler)(nil).UpdatePrometheusRuleDeployment), template)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCoreOSPrometheusRuleDeployment", reflect.TypeOf((*MockPrometheusRuleHandler)(nil).UpdateCoreOSPrometheusRuleDeployment), template)
+}
+
+// UpdateRHOBSPrometheusRuleDeployment mocks base method.
+func (m *MockPrometheusRuleHandler) UpdateRHOBSPrometheusRuleDeployment(template v10.PrometheusRule) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRHOBSPrometheusRuleDeployment", template)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateRHOBSPrometheusRuleDeployment indicates an expected call of UpdateRHOBSPrometheusRuleDeployment.
+func (mr *MockPrometheusRuleHandlerMockRecorder) UpdateRHOBSPrometheusRuleDeployment(template interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRHOBSPrometheusRuleDeployment", reflect.TypeOf((*MockPrometheusRuleHandler)(nil).UpdateRHOBSPrometheusRuleDeployment), template)
 }
 
 // MockBlackBoxExporterHandler is a mock of BlackBoxExporterHandler interface.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-21000

---

Updates the prometheusrule deployment logic to create `prometheusrule.monitoring.rhobs` objects instead of `prometheusrule.monitoring.coreos.com` objects when a `routemonitor`'s `.spec.ServiceMonitorType` is `monitoring.rhobs`.

This is required for the RHOBS prometheus instances to generate alerts from the metrics they're capturing from their servicemonitor.