### PR TITLE
Revert "Deploy RHOBS prometheusrules when using a RHOBS servicemonitors"

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -77,7 +77,6 @@ rules:
   - watch
 - apiGroups:
   - monitoring.coreos.com
-  - monitoring.rhobs
   resources:
   - prometheusrules
   verbs:

--- a/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_supplement.go
@@ -69,8 +69,8 @@ func (s *ClusterUrlMonitorReconciler) EnsurePrometheusRuleExists(clusterUrlMonit
 	}
 
 	namespacedName := types.NamespacedName{Namespace: clusterUrlMonitor.Namespace, Name: clusterUrlMonitor.Name}
-	template := alert.TemplateForCoreOSPrometheusRuleResource(clusterUrl, parsedSlo, namespacedName)
-	err = s.Prom.UpdateCoreOSPrometheusRuleDeployment(template)
+	template := alert.TemplateForPrometheusRuleResource(clusterUrl, parsedSlo, namespacedName)
+	err = s.Prom.UpdatePrometheusRuleDeployment(template)
 	if err != nil {
 		return utilreconcile.RequeueReconcileWith(err)
 	}

--- a/controllers/clusterurlmonitor/clusterurlmonitor_test.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Clusterurlmonitor", func() {
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockCommon.EXPECT().ParseMonitorSLOSpecs(gomock.Any(), clusterUrlMonitor.Spec.Slo).Times(1).Return("99.5", nil)
 				mockCommon.EXPECT().SetErrorStatus(&clusterUrlMonitor.Status.ErrorStatus, nil)
-				mockPrometheusRule.EXPECT().UpdateCoreOSPrometheusRuleDeployment(gomock.Any()).Times(1)
+				mockPrometheusRule.EXPECT().UpdatePrometheusRuleDeployment(gomock.Any()).Times(1)
 				mockCommon.EXPECT().SetResourceReference(&clusterUrlMonitor.Status.PrometheusRuleRef, gomock.Any()).Times(1).Return(false, nil)
 			})
 			It("doesn't update the clusterUrlMonitor reference and continues reconciling", func() {
@@ -143,7 +143,7 @@ var _ = Describe("Clusterurlmonitor", func() {
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockCommon.EXPECT().ParseMonitorSLOSpecs(gomock.Any(), clusterUrlMonitor.Spec.Slo).Times(1).Return("99.5", nil)
 				mockCommon.EXPECT().SetErrorStatus(&clusterUrlMonitor.Status.ErrorStatus, nil)
-				mockPrometheusRule.EXPECT().UpdateCoreOSPrometheusRuleDeployment(gomock.Any()).Times(1)
+				mockPrometheusRule.EXPECT().UpdatePrometheusRuleDeployment(gomock.Any()).Times(1)
 				ns := types.NamespacedName{Name: clusterUrlMonitor.Name, Namespace: clusterUrlMonitor.Namespace}
 				mockCommon.EXPECT().SetResourceReference(&clusterUrlMonitor.Status.PrometheusRuleRef, ns).Times(1).Return(true, nil)
 				mockCommon.EXPECT().UpdateMonitorResourceStatus(&clusterUrlMonitor).Times(1).Return(utilreconcile.StopOperation(), nil)

--- a/controllers/interfaces.go
+++ b/controllers/interfaces.go
@@ -75,15 +75,10 @@ type ServiceMonitorHandler interface {
 }
 
 type PrometheusRuleHandler interface {
-	// UpdateCoreOSPrometheusRuleDeployment ensures that a PrometheusRule.monitoring.coreos.com deployment according
+	// UpdatePrometheusRuleDeployment ensures that a PrometheusRule deployment according
 	// to the template exists. If none exists, it will create a new one.
 	// If the template changed, it will update the existing deployment
-	UpdateCoreOSPrometheusRuleDeployment(template monitoringv1.PrometheusRule) error
-
-	// UpdateRHOBSPrometheusRuleDeployment ensures that a PrometheusRule.monitoring.rhobs deployment according
-	// to the template exists. If none exists, it will create a new one.
-	// If the template changed, it will update the existing deployment
-	UpdateRHOBSPrometheusRuleDeployment(template rhobsv1.PrometheusRule) error
+	UpdatePrometheusRuleDeployment(template monitoringv1.PrometheusRule) error
 
 	// DeletePrometheusRuleDeployment deletes a PrometheusRule refrenced by a namespaced name
 	DeletePrometheusRuleDeployment(prometheusRuleRef v1alpha1.NamespacedName) error

--- a/controllers/routemonitor/routemonitor_supplement.go
+++ b/controllers/routemonitor/routemonitor_supplement.go
@@ -54,18 +54,10 @@ func (r *RouteMonitorReconciler) EnsurePrometheusRuleExists(routeMonitor v1alpha
 
 	// Update PrometheusRule from templates
 	namespacedName := types.NamespacedName{Namespace: routeMonitor.Namespace, Name: routeMonitor.Name}
-	if routeMonitor.Spec.ServiceMonitorType == v1alpha1.ServiceMonitorTypeRHOBS {
-		template := alert.TemplateForRHOBSPrometheusRuleResource(routeMonitor.Status.RouteURL, parsedSlo, namespacedName)
-		err = r.Prom.UpdateRHOBSPrometheusRuleDeployment(template)
-		if err != nil {
-			return utilreconcile.RequeueReconcileWith(err)
-		}
-	} else {
-		template := alert.TemplateForCoreOSPrometheusRuleResource(routeMonitor.Status.RouteURL, parsedSlo, namespacedName)
-		err = r.Prom.UpdateCoreOSPrometheusRuleDeployment(template)
-		if err != nil {
-			return utilreconcile.RequeueReconcileWith(err)
-		}
+	template := alert.TemplateForPrometheusRuleResource(routeMonitor.Status.RouteURL, parsedSlo, namespacedName)
+	err = r.Prom.UpdatePrometheusRuleDeployment(template)
+	if err != nil {
+		return utilreconcile.RequeueReconcileWith(err)
 	}
 
 	// Update PrometheusRuleReference in RouteMonitor if necessary
@@ -91,7 +83,11 @@ func (r *RouteMonitorReconciler) EnsureServiceMonitorExists(routeMonitor v1alpha
 		return utilreconcile.RequeueReconcileWith(err)
 	}
 
-	useRHOBS := (routeMonitor.Spec.ServiceMonitorType == v1alpha1.ServiceMonitorTypeRHOBS)
+	useRHOBS := false
+	if routeMonitor.Spec.ServiceMonitorType == v1alpha1.ServiceMonitorTypeRHOBS {
+		useRHOBS = true
+	}
+
 	owner := metav1.NewControllerRef(&routeMonitor.ObjectMeta, routeMonitor.GroupVersionKind())
 	if err := r.ServiceMonitor.TemplateAndUpdateServiceMonitorDeployment(routeMonitor.Status.RouteURL, r.BlackBoxExporter.GetBlackBoxExporterNamespace(), namespacedName, id, useRHOBS, routeMonitor.Spec.InsecureSkipTLSVerify, owner); err != nil {
 		return utilreconcile.RequeueReconcileWith(err)

--- a/controllers/routemonitor/routemonitor_test.go
+++ b/controllers/routemonitor/routemonitor_test.go
@@ -718,7 +718,7 @@ var _ = Describe("Routemonitor", func() {
 			})
 			When("the update the PrometheusRule failed", func() {
 				BeforeEach(func() {
-					mockPrometheusRule.EXPECT().UpdateCoreOSPrometheusRuleDeployment(gomock.Any()).Return(consterror.CustomError)
+					mockPrometheusRule.EXPECT().UpdatePrometheusRuleDeployment(gomock.Any()).Return(consterror.CustomError)
 				})
 				It("requeues with the error", func() {
 					Expect(err).To(Equal(consterror.CustomError))
@@ -727,7 +727,7 @@ var _ = Describe("Routemonitor", func() {
 			})
 			When("the update of the PrometheusRule succeded", func() {
 				BeforeEach(func() {
-					mockPrometheusRule.EXPECT().UpdateCoreOSPrometheusRuleDeployment(gomock.Any())
+					mockPrometheusRule.EXPECT().UpdatePrometheusRuleDeployment(gomock.Any())
 				})
 				When("a new PrometheusRule was created", func() {
 					BeforeEach(func() {

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -79,7 +79,6 @@ rules:
       - watch
   - apiGroups:
       - monitoring.coreos.com
-      - monitoring.rhobs
     resources:
       - prometheusrules
     verbs:

--- a/int/integration.go
+++ b/int/integration.go
@@ -226,7 +226,7 @@ func (i *Integration) RouteMonitorWaitForPrometheusRuleCorrectSLO(name types.Nam
 		return err
 	}
 
-	template := alert.TemplateForCoreOSPrometheusRuleResource(routeMonitor.Status.RouteURL, targetSlo, name)
+	template := alert.TemplateForPrometheusRuleResource(routeMonitor.Status.RouteURL, targetSlo, name)
 	t := 0
 	for ; t < seconds; t++ {
 		err := i.Client.Get(context.TODO(), name, &prometheusRule)
@@ -263,7 +263,7 @@ func (i *Integration) ClusterUrlMonitorWaitForPrometheusRuleCorrectSLO(name type
 		return err
 	}
 
-	template := alert.TemplateForCoreOSPrometheusRuleResource(expectedUrl, targetSlo, name)
+	template := alert.TemplateForPrometheusRuleResource(expectedUrl, targetSlo, name)
 	t := 0
 	for ; t < seconds; t++ {
 		err := i.Client.Get(context.TODO(), name, &prometheusRule)

--- a/main.go
+++ b/main.go
@@ -173,9 +173,9 @@ func main() {
 }
 
 // shouldEnableHCP checks for the existence of the 'hostedcontrolplane' CRD to determine whether this controller should be enabled or not:
-//   - if it exists, enable the HCP controller
-//   - if we get an error unrelated to it's existence (ie - kubeapiserver is down) return the error
-//   - if we get an error due to it not existing, disable the HCP controller
+//  - if it exists, enable the HCP controller
+//  - if we get an error unrelated to it's existence (ie - kubeapiserver is down) return the error
+//  - if we get an error due to it not existing, disable the HCP controller
 func shouldEnableHCP(mgr ctrl.Manager) (bool, error) {
 	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {

--- a/pkg/alert/prometheusrule_test.go
+++ b/pkg/alert/prometheusrule_test.go
@@ -95,7 +95,7 @@ var _ = Describe("CR Deployment Handling", func() {
 			get.CalledTimes = 1
 		})
 		JustBeforeEach(func() {
-			err = pr.UpdateCoreOSPrometheusRuleDeployment(prometheusRule)
+			err = pr.UpdatePrometheusRuleDeployment(prometheusRule)
 		})
 		When("the Client failed to fetch existing deployments", func() {
 			BeforeEach(func() {

--- a/pkg/util/test/generated/mocks/controllers/interfaces.go
+++ b/pkg/util/test/generated/mocks/controllers/interfaces.go
@@ -305,32 +305,18 @@ func (mr *MockPrometheusRuleHandlerMockRecorder) DeletePrometheusRuleDeployment(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePrometheusRuleDeployment", reflect.TypeOf((*MockPrometheusRuleHandler)(nil).DeletePrometheusRuleDeployment), prometheusRuleRef)
 }
 
-// UpdateCoreOSPrometheusRuleDeployment mocks base method.
-func (m *MockPrometheusRuleHandler) UpdateCoreOSPrometheusRuleDeployment(template v1.PrometheusRule) error {
+// UpdatePrometheusRuleDeployment mocks base method.
+func (m *MockPrometheusRuleHandler) UpdatePrometheusRuleDeployment(template v1.PrometheusRule) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCoreOSPrometheusRuleDeployment", template)
+	ret := m.ctrl.Call(m, "UpdatePrometheusRuleDeployment", template)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateCoreOSPrometheusRuleDeployment indicates an expected call of UpdateCoreOSPrometheusRuleDeployment.
-func (mr *MockPrometheusRuleHandlerMockRecorder) UpdateCoreOSPrometheusRuleDeployment(template interface{}) *gomock.Call {
+// UpdatePrometheusRuleDeployment indicates an expected call of UpdatePrometheusRuleDeployment.
+func (mr *MockPrometheusRuleHandlerMockRecorder) UpdatePrometheusRuleDeployment(template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCoreOSPrometheusRuleDeployment", reflect.TypeOf((*MockPrometheusRuleHandler)(nil).UpdateCoreOSPrometheusRuleDeployment), template)
-}
-
-// UpdateRHOBSPrometheusRuleDeployment mocks base method.
-func (m *MockPrometheusRuleHandler) UpdateRHOBSPrometheusRuleDeployment(template v10.PrometheusRule) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRHOBSPrometheusRuleDeployment", template)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateRHOBSPrometheusRuleDeployment indicates an expected call of UpdateRHOBSPrometheusRuleDeployment.
-func (mr *MockPrometheusRuleHandlerMockRecorder) UpdateRHOBSPrometheusRuleDeployment(template interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRHOBSPrometheusRuleDeployment", reflect.TypeOf((*MockPrometheusRuleHandler)(nil).UpdateRHOBSPrometheusRuleDeployment), template)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePrometheusRuleDeployment", reflect.TypeOf((*MockPrometheusRuleHandler)(nil).UpdatePrometheusRuleDeployment), template)
 }
 
 // MockBlackBoxExporterHandler is a mock of BlackBoxExporterHandler interface.


### PR DESCRIPTION
Reverts openshift/route-monitor-operator#270, since on-cluster `prometheusrules.monitoring.rhobs` objects do not impact alerting in Hypershift.