### PR TITLE
Change blackbox exporter scheduling to control-plane nodes for 4.13 if IC is NLB

### DIFF
--- a/pkg/blackboxexporter/blackboxexporter.go
+++ b/pkg/blackboxexporter/blackboxexporter.go
@@ -143,7 +143,7 @@ func (b *BlackBoxExporter) EnsureBlackBoxExporterConfigMapExists() error {
 // deploymentForBlackBoxExporter returns a blackbox deployment
 func (b *BlackBoxExporter) templateForBlackBoxExporterDeployment(blackBoxImage string, blackBoxNamespacedName types.NamespacedName) appsv1.Deployment {
 	nodeLabel := "node-role.kubernetes.io/infra"
-	if util.IsClusterVersionHigherOrEqualThan(b.Client, "4.14") && util.ClusterHasPrivateNLB(b.Client) {
+	if util.IsClusterVersionHigherOrEqualThan(b.Client, "4.13") && util.ClusterHasPrivateNLB(b.Client) {
 		nodeLabel = "node-role.kubernetes.io/master"
 	}
 


### PR DESCRIPTION
When the NLB changes were allowed for the default IngressController, 4.14 was the "GA" version for OSD/ROSA, but through support exception some customers were allowed to use it on 4.13. This PR handles the case where the NLB for the default IC has been enabled on a 4.13 cluster. 

Fixes https://issues.redhat.com/browse/OSD-21661