### PR TITLE
[OSD-22081] Always run blackbox-exporter on master nodes.

### DIFF
--- a/pkg/blackboxexporter/blackboxexporter.go
+++ b/pkg/blackboxexporter/blackboxexporter.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/openshift/route-monitor-operator/api/v1alpha1"
 	"github.com/openshift/route-monitor-operator/pkg/consts/blackboxexporter"
-	"github.com/openshift/route-monitor-operator/pkg/util"
 	"github.com/openshift/route-monitor-operator/pkg/util/finalizer"
 
 	"context"
@@ -142,10 +141,7 @@ func (b *BlackBoxExporter) EnsureBlackBoxExporterConfigMapExists() error {
 
 // deploymentForBlackBoxExporter returns a blackbox deployment
 func (b *BlackBoxExporter) templateForBlackBoxExporterDeployment(blackBoxImage string, blackBoxNamespacedName types.NamespacedName) appsv1.Deployment {
-	nodeLabel := "node-role.kubernetes.io/infra"
-	if util.IsClusterVersionHigherOrEqualThan(b.Client, "4.13") && util.ClusterHasPrivateNLB(b.Client) {
-		nodeLabel = "node-role.kubernetes.io/master"
-	}
+	nodeLabel := "node-role.kubernetes.io/master"
 
 	labels := blackboxexporter.GenerateBlackBoxExporterLables()
 	labelSelectors := metav1.LabelSelector{

--- a/pkg/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/blackboxexporter/blackboxexporter_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Blackboxexporter", func() {
 	Describe("CreateBlackBoxExporterDeployment", func() {
 		BeforeEach(func() {
 			// Arrange
-			get.CalledTimes = 2
+			get.CalledTimes = 1
 		})
 
 		When("the resource(deployment) is Not Found", func() {


### PR DESCRIPTION
This change should help prevent issues, when placing an exporter pod on an infra node that is not running a dns pod.

This can lead to DNS failures if the load-balanced DNS pod on non-infra node is not responding in time, due to node-load.

Master nodes should always run their own dns pod that will be preferred.