### PR TITLE
Bump to go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/route-monitor-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
This repo has had its boilerplate bumped to 5.0.1, which is go 1.22. This PR bumps the code to go 1.22 as well.