### PR TITLE
Add :z to Makefile package target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ endif
 
 .PHONY: package
 package: kubectl-package
-	$(CONTAINER_ENGINE) run --rm -v ${PWD}:/workdir quay.io/app-sre/yq:4 '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
+	$(CONTAINER_ENGINE) run --rm -v ${PWD}:/workdir:z quay.io/app-sre/yq:4 '.spec.template.spec.containers[0].image = "$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME):$(OPERATOR_IMAGE_TAG)"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
 	$(CONTAINER_ENGINE) login -u $(QUAY_USER) -p $(QUAY_TOKEN) quay.io
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:$(OPERATOR_IMAGE_TAG) --push packaging/
 	DOCKER_CONFIG=$(CONTAINER_ENGINE_CONFIG_DIR)/ ./bin/kubectl-package build -t $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(OPERATOR_NAME)-hs-package:latest --push packaging/


### PR DESCRIPTION
This should fix the app-sre build job, which is currently failing with the following error after the boilerplate bump:
```
09:07:23 /usr/bin/podman run --rm -v /var/lib/jenkins/workspace/openshift-route-monitor-operator-gh-build-master:/workdir quay.io/app-sre/yq:4 '.spec.template.spec.containers[0].image = "quay.io/app-sre/route-monitor-operator:v0.1.669-gda7a484"' deploy/route-monitor-operator-controller-manager.Deployment.yaml > packaging/06-deploy/route-monitor-operator-controller-manager.Deployment.yaml
09:07:23 Error: open deploy/route-monitor-operator-controller-manager.Deployment.yaml: permission denied
```