### PR TITLE
Remove config from template for security best practices for api server monitoring

### DIFF
--- a/pkg/dynatrace/dynatrace.go
+++ b/pkg/dynatrace/dynatrace.go
@@ -54,10 +54,6 @@ var publicMonitorTemplate = `
                 "url": "{{.ApiUrl}}",
                 "method": "GET",
                 "requestBody": "",
-                "configuration": {
-                    "acceptAnyCertificate": true,
-                    "followRedirects": true
-                },
                 "preProcessingScript": "",
                 "postProcessingScript": ""
             }


### PR DESCRIPTION
Remove config from template for security best practices for api server monitoring. No need for 'acceptAnyCertificate: true' and  'followRedirects: true' for api server livez endpoint. Tested in int.

Ticket - https://issues.redhat.com/browse/OSD-20249