### PR TITLE
OSD-25505: Bump memory limit for RMO controller manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 400Mi
+              memory: 2000Mi
             requests:
               cpu: 100m
               memory: 20Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 2000Mi
+              memory: 1000Mi
             requests:
               cpu: 100m
               memory: 20Mi

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -67,7 +67,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 400Mi
+              memory: 2000Mi
             requests:
               cpu: 100m
               memory: 20Mi

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -67,7 +67,7 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 2000Mi
+              memory: 1000Mi
             requests:
               cpu: 100m
               memory: 20Mi


### PR DESCRIPTION
**What?**

RMO is getting oomkilled when a lot of clusters deprovision at the same time on a MC. This PR bumps the memory limit to avoid this situation.

https://issues.redhat.com/browse/OSD-25505