### PR TITLE
OSD-26305 - Change blackboxexporter tag from 'master' to 'latest'

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	var blackboxExporterImage string
 	var blackboxExporterNamespace string
 
-	flag.StringVar(&blackboxExporterImage, "blackbox-image", "quay.io/prometheus/blackbox-exporter:master", "The image that will be used for the blackbox-exporter deployment")
+	flag.StringVar(&blackboxExporterImage, "blackbox-image", "quay.io/prometheus/blackbox-exporter@sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e", "The image that will be used for the blackbox-exporter deployment")
 	flag.StringVar(&blackboxExporterNamespace, "blackbox-namespace", config.OperatorNamespace, "Blackbox-exporter deployment will reside on this Namespace")
 
 	opts := zap.Options{}


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-26305

---

Updates RMO's blackboxexporter deployment image tag from `master` to `latest`. 

SRE was informed that using the `master` blackboxexporter container image is unstable, since this tag seems to  get updated automatically everytime the blackboxexporter codebase merges a new commit. As a result, the tag's historical images are not available for vulnerability scanning.