### PR TITLE
Revert "Revert "Support Private HCP API Monitoring""

### DIFF
--- a/controllers/hostedcontrolplane/hostedcontrolplane.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane.go
@@ -390,6 +390,48 @@ func (r *HostedControlPlaneReconciler) getDynatraceSecrets(ctx context.Context) 
 	return valueDynatraceApiToken, valueDynatraceTenant, nil
 }
 
+func getDynatraceEquivalentClusterRegionName(clusterRegion string) (string, error) {
+	// Adapted from spreadsheet in https://issues.redhat.com/browse/SDE-3754
+	// Coming soon regions - il-central-1, ca-west-1
+	awsRegionToDyntraceRegionMapping := map[string]string{
+		"us-east-1":      "N. Virginia",
+		"us-east-2":      "N. Virginia",
+		"us-west-1":      "Oregon",
+		"us-west-2":      "Oregon",
+		"af-south-1":     "São Paulo",
+		"ap-southeast-1": "Singapore",
+		"ap-southeast-2": "Sydney",
+		"ap-southeast-3": "Singapore",
+		"ap-southeast-4": "Sydney",
+		"ap-northeast-1": "Singapore",
+		"ap-northeast-2": "Sydney",
+		"ap-northeast-3": "Singapore",
+		"ap-south-1":     "Mumbai",
+		"ap-south-2":     "Mumbai",
+		"ap-east-1":      "Singapore",
+		"ca-central-1":   "Montreal",
+		"eu-west-1":      "Dublin",
+		"eu-west-2":      "London",
+		"eu-west-3":      "Frankfurt",
+		"eu-central-1":   "Frankfurt",
+		"eu-central-2":   "Frankfurt",
+		"eu-south-1":     "Frankfurt",
+		"eu-south-2":     "Frankfurt",
+		"eu-north-1":     "London",
+		"me-south-1":     "Mumbai",
+		"me-central-1":   "Mumbai",
+		"sa-east-1":      "São Paulo",
+	}
+
+	// Look up the equivalent dynatrace location name based on the aws region in map
+	//e.g. "us-east-2" in aws has equivalent "N. Virginia" in Dynatrace Locations
+	dynatraceLocationName, ok := awsRegionToDyntraceRegionMapping[clusterRegion]
+	if !ok {
+		return "", fmt.Errorf("location not found for region: %s", clusterRegion)
+	}
+	return dynatraceLocationName, nil
+}
+
 func getDynatraceHttpMonitorId(hostedcontrolplane *hypershiftv1beta1.HostedControlPlane) (string, bool) {
 	labels := hostedcontrolplane.GetLabels()
 	dynatraceHttpMonitorId, ok := labels[httpMonitorLabel]
@@ -431,6 +473,35 @@ func checkHttpMonitorExists(dynatraceApiClient *dynatrace.DynatraceApiClient, ho
 	return false, nil
 }
 
+func getClusterRegion(hostedcontrolplane *hypershiftv1beta1.HostedControlPlane) (string, error) {
+	if hostedcontrolplane == nil {
+		return "", fmt.Errorf("hostedcontrolplane is nil %v", hostedcontrolplane)
+	}
+
+	clusterRegion := hostedcontrolplane.Spec.Platform.AWS.Region
+	if clusterRegion == "" {
+		return "", fmt.Errorf("aws region is not set in hcp %v", hostedcontrolplane)
+	}
+
+	return clusterRegion, nil
+}
+
+func determineDynatraceClusterRegionName(clusterRegion string, monitorLocationType hypershiftv1beta1.AWSEndpointAccessType) (string, error) {
+	//public
+	if monitorLocationType == hypershiftv1beta1.PublicAndPrivate {
+		return getDynatraceEquivalentClusterRegionName(clusterRegion)
+	} else if monitorLocationType == hypershiftv1beta1.Private {
+		/*
+			For "Private" HCPs, we have one backplane location deployed per dynatrace tenant. E.g. "name": "backplanei03xyz"
+			"backplane" is returned from this function and passed to GetLocationEntityIdFromDynatrace function and this location is
+			searched for in dynatrace - if strings.Contains(loc.Name, locationName) && loc.Type == "PRIVATE" && loc.Status == "ENABLED".
+			Ref: https://issues.redhat.com/browse/OSD-25167
+		*/
+		return "backplane", nil
+	}
+	return "", fmt.Errorf("monitorLocationType '%s' not supported", monitorLocationType)
+}
+
 func (r *HostedControlPlaneReconciler) deployDynatraceHttpMonitorResources(ctx context.Context, dynatraceApiClient *dynatrace.DynatraceApiClient, log logr.Logger, hostedcontrolplane *hypershiftv1beta1.HostedControlPlane) error {
 	//if http monitor does not exist, and hcp is not marked for deletion, and hcp is ready, then create http monitor
 	//get apiserver
@@ -440,7 +511,7 @@ func (r *HostedControlPlaneReconciler) deployDynatraceHttpMonitorResources(ctx c
 	}
 	monitorName := strings.Replace(apiServerHostname, "api.", "", 1)
 	// apiServerHostname := hostedcontrolplane.Spec.Services[1].ServicePublishingStrategy.Route.Hostname
-	monitorLocation := hostedcontrolplane.Spec.Platform.AWS.EndpointAccess
+	monitorLocationType := hostedcontrolplane.Spec.Platform.AWS.EndpointAccess
 
 	//in hcp, spec.services.service["APIServer"].servicePublishingStrategy.route.hostname is api.test-rs1.dgcj.i3.devshift.org
 	// apiUrl := "https://api.hb-testing.j1b6.i3.devshift.org/livez"
@@ -456,41 +527,40 @@ func (r *HostedControlPlaneReconciler) deployDynatraceHttpMonitorResources(ctx c
 		return nil
 	}
 
-	// determine location and create monitor
-	//public
-	if monitorLocation == "PublicAndPrivate" {
-
-		clusterId := hostedcontrolplane.Spec.ClusterID
-		clusterRegion := hostedcontrolplane.Spec.Platform.AWS.Region
-
-		dynatraceEquivalentClusterRegionId, err := dynatraceApiClient.GetDynatraceEquivalentClusterRegionId(clusterRegion)
-		if err != nil {
-			return fmt.Errorf("error getting DynatraceEquivalentClusterRegionId: %v", err)
-		}
-
-		monitorId, err := dynatraceApiClient.CreateDynatraceHttpMonitor(monitorName, apiUrl, clusterId, dynatraceEquivalentClusterRegionId)
-		if err != nil {
-			return fmt.Errorf("error creating HTTP monitor: %v", err)
-		}
-
-		err = r.UpdateHostedControlPlaneLabels(ctx, hostedcontrolplane, httpMonitorLabel, monitorId)
-		//if UpdateHostedControlPlaneLabels fails, delete the http monitor, reconcile the hcp and create a new monitor
-		if err != nil {
-			deleteErr := dynatraceApiClient.DeleteDynatraceHttpMonitor(monitorId)
-			if deleteErr != nil {
-				log.Error(deleteErr, "error deleting HTTP monitor")
-			}
-			return fmt.Errorf("failed to update hostedcontrolplane monitor labels %v", err)
-		}
-
-		log.Info("Created HTTP monitor ", monitorId, clusterId)
+	clusterId := hostedcontrolplane.Spec.ClusterID
+	/* determine cluster region, find cluster region equivalent name in dynatrace, fetch locationId/entityId
+	of the cluster region equivalent name in dynatrace, create http monitor and then update hcp labels.
+	*/
+	clusterRegion, err := getClusterRegion(hostedcontrolplane)
+	if err != nil {
+		return fmt.Errorf("error calling getClusterRegion: %v", err)
+	}
+	dynatraceClusterRegionName, err := determineDynatraceClusterRegionName(clusterRegion, monitorLocationType)
+	if err != nil {
+		return fmt.Errorf("error calling determineDynatraceClusterRegionId: %v", err)
 	}
 
-	//private not supported yet
-	if monitorLocation == "Private" {
-		log.Info("Private API - Not supported yet.")
-		return nil
+	locationId, err := dynatraceApiClient.GetLocationEntityIdFromDynatrace(dynatraceClusterRegionName, monitorLocationType)
+	if err != nil {
+		return fmt.Errorf("error calling GetLocationEntityIdFromDynatrace: %v", err)
 	}
+
+	monitorId, err := dynatraceApiClient.CreateDynatraceHttpMonitor(monitorName, apiUrl, clusterId, locationId, clusterRegion)
+	if err != nil {
+		return fmt.Errorf("error creating HTTP monitor: %v", err)
+	}
+
+	err = r.UpdateHostedControlPlaneLabels(ctx, hostedcontrolplane, httpMonitorLabel, monitorId)
+	//if UpdateHostedControlPlaneLabels fails, delete the http monitor, reconcile the hcp and create a new monitor
+	if err != nil {
+		deleteErr := dynatraceApiClient.DeleteDynatraceHttpMonitor(monitorId)
+		if deleteErr != nil {
+			log.Error(deleteErr, "error deleting HTTP monitor")
+		}
+		return fmt.Errorf("failed to update hostedcontrolplane monitor labels %v", err)
+	}
+
+	log.Info("Created HTTP monitor ", monitorId, clusterId)
 
 	return nil
 }

--- a/controllers/hostedcontrolplane/hostedcontrolplane_test.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane_test.go
@@ -1215,3 +1215,196 @@ func TestAPIClient_DeleteDynatraceHTTPMonitorResources(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDynatraceEquivalentClusterRegionId(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterRegion string
+		expectId      string
+		expectError   bool
+	}{
+		{
+			name:          "us-east-1",
+			clusterRegion: "us-east-1",
+			expectId:      "N. Virginia",
+			expectError:   false,
+		},
+		{
+			name:          "us-west-2",
+			clusterRegion: "us-west-2",
+			expectId:      "Oregon",
+			expectError:   false,
+		},
+		{
+			name:          "ap-south-1",
+			clusterRegion: "ap-south-1",
+			expectId:      "Mumbai",
+			expectError:   false,
+		},
+		{
+			name:          "non-existent region",
+			clusterRegion: "non-existent-region",
+			expectId:      "",
+			expectError:   true,
+		},
+		{
+			name:          "us-east-2",
+			clusterRegion: "us-east-2",
+			expectId:      "N. Virginia",
+			expectError:   false,
+		},
+		{
+			name:          "eu-central-1",
+			clusterRegion: "eu-central-1",
+			expectId:      "Frankfurt",
+			expectError:   false,
+		},
+		{
+			name:          "me-south-1",
+			clusterRegion: "me-south-1",
+			expectId:      "Mumbai",
+			expectError:   false,
+		},
+		{
+			name:          "invalid region format",
+			clusterRegion: "invalid-region",
+			expectId:      "",
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function to test
+			id, err := getDynatraceEquivalentClusterRegionName(tt.clusterRegion)
+
+			// Verify the results
+			if id != tt.expectId {
+				t.Errorf("Unexpected ID. Expected: %v, got: %v", tt.expectId, id)
+			}
+			if (err != nil) != tt.expectError {
+				t.Errorf("Unexpected error status. Expected error: %v, got: %v", tt.expectError, err)
+			}
+		})
+	}
+}
+
+func TestDetermineDynatraceClusterRegionName(t *testing.T) {
+	tests := []struct {
+		name                string
+		clusterRegion       string
+		monitorLocationType hypershiftv1beta1.AWSEndpointAccessType
+		expectId            string
+		expectError         bool
+	}{
+		{
+			name:                "Valid PublicAndPrivate region",
+			clusterRegion:       "us-east-1",
+			monitorLocationType: hypershiftv1beta1.PublicAndPrivate,
+			expectId:            "N. Virginia", // Adjust according to your mapping
+			expectError:         false,
+		},
+		{
+			name:                "Valid Private region",
+			clusterRegion:       "us-west-2",
+			monitorLocationType: hypershiftv1beta1.Private,
+			expectId:            "backplane",
+			expectError:         false,
+		},
+		{
+			name:                "Invalid region for PublicAndPrivate",
+			clusterRegion:       "invalid-region",
+			monitorLocationType: hypershiftv1beta1.PublicAndPrivate,
+			expectId:            "",
+			expectError:         true,
+		},
+		{
+			name:                "Invalid region for Private",
+			clusterRegion:       "invalid-region",
+			monitorLocationType: hypershiftv1beta1.Private,
+			expectId:            "backplane",
+			expectError:         false,
+		},
+		{
+			name:                "Unsupported monitorLocationType",
+			clusterRegion:       "us-east-1",
+			monitorLocationType: "UnknownType",
+			expectId:            "",
+			expectError:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function to test
+			id, err := determineDynatraceClusterRegionName(tt.clusterRegion, tt.monitorLocationType)
+
+			// Verify the results
+			if id != tt.expectId {
+				t.Errorf("Unexpected ID. Expected: %v, got: %v", tt.expectId, id)
+			}
+			if (err != nil) != tt.expectError {
+				t.Errorf("Unexpected error status. Expected error: %v, got: %v", tt.expectError, err)
+			}
+		})
+	}
+}
+
+func TestGetClusterRegion(t *testing.T) {
+	tests := []struct {
+		name               string
+		hostedControlPlane *hypershiftv1beta1.HostedControlPlane
+		expectRegion       string
+		expectError        bool
+	}{
+		{
+			name: "Valid AWS region",
+			hostedControlPlane: &hypershiftv1beta1.HostedControlPlane{
+				Spec: hypershiftv1beta1.HostedControlPlaneSpec{
+					Platform: hypershiftv1beta1.PlatformSpec{
+						AWS: &hypershiftv1beta1.AWSPlatformSpec{
+							Region: "us-west-2",
+						},
+					},
+				},
+			},
+			expectRegion: "us-west-2",
+			expectError:  false,
+		},
+		{
+			name:               "Hosted control plane is nil",
+			hostedControlPlane: nil,
+			expectRegion:       "",
+			expectError:        true,
+		},
+		{
+			name: "AWS region is empty",
+			hostedControlPlane: &hypershiftv1beta1.HostedControlPlane{
+				Spec: hypershiftv1beta1.HostedControlPlaneSpec{
+					Platform: hypershiftv1beta1.PlatformSpec{
+						AWS: &hypershiftv1beta1.AWSPlatformSpec{
+							Region: "",
+						},
+					},
+				},
+			},
+			expectRegion: "",
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function to test
+			region, err := getClusterRegion(tt.hostedControlPlane)
+
+			// Verify the results
+			if region != tt.expectRegion {
+				t.Errorf("Unexpected region. Expected: %v, got: %v", tt.expectRegion, region)
+			}
+			if (err != nil) != tt.expectError {
+				t.Errorf("Unexpected error status. Expected error: %v, got: %v", tt.expectError, err)
+			}
+		})
+	}
+}

--- a/pkg/dynatrace/dynatrace.go
+++ b/pkg/dynatrace/dynatrace.go
@@ -23,6 +23,9 @@ import (
 	"html/template"
 	"io"
 	"net/http"
+	"strings"
+
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 )
 
 // ------------------------------synthetic-monitoring--------------------------
@@ -84,6 +87,10 @@ var publicMonitorTemplate = `
             "key": "cluster-id",
             "value": "{{.ClusterId}}"
         },
+		{
+            "key": "cluster-region",
+            "value": "{{.ClusterRegion}}"
+        },
         {
             "key": "route-monitor-operator-managed",
             "value": "true"
@@ -101,6 +108,7 @@ type DynatraceMonitorConfig struct {
 	ApiUrl                             string
 	DynatraceEquivalentClusterRegionId string
 	ClusterId                          string
+	ClusterRegion                      string
 }
 
 type DynatraceCreatedMonitor struct {
@@ -113,6 +121,7 @@ type DynatraceLocation struct {
 		Type          string `json:"type"`
 		CloudPlatform string `json:"cloudPlatform"`
 		EntityId      string `json:"entityId"`
+		Status        string `json:"status"`
 	} `json:"locations"`
 }
 
@@ -142,47 +151,8 @@ func (dynatraceApiClient *DynatraceApiClient) MakeRequest(method, path string, r
 	return dynatraceApiClient.httpClient.Do(req)
 }
 
-func (dynatraceApiClient *DynatraceApiClient) GetDynatraceEquivalentClusterRegionId(clusterRegion string) (string, error) {
-	// Adapted from spreadsheet in https://issues.redhat.com//browse/SDE-3754
-	// Coming soon regions - il-central-1, ca-west-1
-	awsRegionToDyntraceRegionMapping := map[string]string{
-		"us-east-1":      "N. Virginia",
-		"us-east-2":      "N. Virginia",
-		"us-west-1":      "Oregon",
-		"us-west-2":      "Oregon",
-		"af-south-1":     "São Paulo",
-		"ap-southeast-1": "Singapore",
-		"ap-southeast-2": "Sydney",
-		"ap-southeast-3": "Singapore",
-		"ap-southeast-4": "Sydney",
-		"ap-northeast-1": "Singapore",
-		"ap-northeast-2": "Sydney",
-		"ap-northeast-3": "Singapore",
-		"ap-south-1":     "Mumbai",
-		"ap-south-2":     "Mumbai",
-		"ap-east-1":      "Singapore",
-		"ca-central-1":   "Montreal",
-		"eu-west-1":      "Dublin",
-		"eu-west-2":      "London",
-		"eu-west-3":      "Frankfurt",
-		"eu-central-1":   "Frankfurt",
-		"eu-central-2":   "Frankfurt",
-		"eu-south-1":     "Frankfurt",
-		"eu-south-2":     "Frankfurt",
-		"eu-north-1":     "London",
-		"me-south-1":     "Mumbai",
-		"me-central-1":   "Mumbai",
-		"sa-east-1":      "São Paulo",
-	}
-
-	// Look up the equivalent dynatrace location name based on the aws region in map
-	//e.g. "us-east-2" in aws has equivalent "N. Virginia" in Dynatrace Locations
-	dynatraceLocationName, ok := awsRegionToDyntraceRegionMapping[clusterRegion]
-	if !ok {
-		return "", fmt.Errorf("location not found for region: %s", clusterRegion)
-	}
-
-	//fetch dynatrace locations using dynatrace api
+func (dynatraceApiClient *DynatraceApiClient) GetLocationEntityIdFromDynatrace(locationName string, locationType hypershiftv1beta1.AWSEndpointAccessType) (string, error) {
+	// Fetch Dynatrace locations using Dynatrace API
 	resp, err := dynatraceApiClient.MakeRequest(http.MethodGet, "/synthetic/locations", "")
 	if err != nil {
 		return "", err
@@ -195,28 +165,50 @@ func (dynatraceApiClient *DynatraceApiClient) GetDynatraceEquivalentClusterRegio
 
 	/*return location id from response body in which dynatrace location is public && CloudPlatform is AWS/AMAZON_EC2
 	e.g. returns exampleLocationId for N. Virginia location in dynatrace in which CloudPlatform is AWS and location is public
-	e.g. response body
+	e.g. PublicAndPrivate response body
 	{
 		"name": "N. Virginia",
 		"entityId": "exampleLocationId",
 		"type": "PUBLIC",
 		"cloudPlatform": "AMAZON_EC2",
+		"status": "ENABLED"
 	}*/
+
+	/*
+		e.g. Private Response body
+		{
+			"name": "backplanei03xyz",
+			"entityId": "privateLocationId",
+			"type": "PRIVATE",
+			"status": "ENABLED"
+		},
+	*/
+	// Decode the response body
 	var locationResponse DynatraceLocation
 	err = json.NewDecoder(resp.Body).Decode(&locationResponse)
 	if err != nil {
 		return "", err
 	}
-	for _, loc := range locationResponse.Locations {
-		if loc.Name == dynatraceLocationName && loc.Type == "PUBLIC" && loc.CloudPlatform == "AMAZON_EC2" {
-			return loc.EntityId, nil
+
+	if locationType == hypershiftv1beta1.PublicAndPrivate {
+		for _, loc := range locationResponse.Locations {
+			if loc.Name == locationName && loc.Type == "PUBLIC" && loc.CloudPlatform == "AMAZON_EC2" && loc.Status == "ENABLED" {
+				return loc.EntityId, nil
+			}
+		}
+	}
+	if locationType == hypershiftv1beta1.Private {
+		for _, loc := range locationResponse.Locations {
+			if strings.Contains(loc.Name, locationName) && loc.Type == "PRIVATE" && loc.Status == "ENABLED" {
+				return loc.EntityId, nil
+			}
 		}
 	}
 
-	return "", fmt.Errorf("location '%s' not found", dynatraceLocationName)
+	return "", fmt.Errorf("location '%s' not found for location type '%s'", locationName, locationType)
 }
 
-func (dynatraceApiClient *DynatraceApiClient) CreateDynatraceHttpMonitor(monitorName, apiUrl, clusterId, dynatraceEquivalentClusterRegionId string) (string, error) {
+func (dynatraceApiClient *DynatraceApiClient) CreateDynatraceHttpMonitor(monitorName, apiUrl, clusterId, dynatraceEquivalentClusterRegionId, clusterRegion string) (string, error) {
 
 	tmpl := template.Must(template.New("jsonTemplate").Parse(publicMonitorTemplate))
 
@@ -225,6 +217,7 @@ func (dynatraceApiClient *DynatraceApiClient) CreateDynatraceHttpMonitor(monitor
 		ApiUrl:                             apiUrl,
 		DynatraceEquivalentClusterRegionId: dynatraceEquivalentClusterRegionId,
 		ClusterId:                          clusterId,
+		ClusterRegion:                      clusterRegion,
 	}
 
 	var tplBuffer bytes.Buffer


### PR DESCRIPTION
Reverts openshift/route-monitor-operator#332

Some context: https://redhat-internal.slack.com/archives/C080QGVCBMK/p1731563952606509?thread_ts=1731559652.618559&cid=C080QGVCBMK
