### PR TITLE
OSD-26305 - Fix additional blackbox exporter tags

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,7 +50,7 @@ spec:
             - name: BLACKBOX_IMAGE
               # override so you can pull any blackbox-exporter image you fancy
               # this value is the default value
-              value: "quay.io/prometheus/blackbox-exporter:master"
+              value: "quay.io/prometheus/blackbox-exporter@sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e"
             - name: BLACKBOX_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: LOG_LEVEL
               value: "1"
             - name: BLACKBOX_IMAGE
-              value: quay.io/prometheus/blackbox-exporter:master
+              value: quay.io/prometheus/blackbox-exporter@sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e
             - name: BLACKBOX_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-26305

---

Follow up to #325; updates additional references of `quay.io/prometheus/blackbox-exporter:master` to `quay.io/prometheus/blackbox-exporter@sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e`.