### PR TITLE
Set Upgrade Strategy to Fail Forward

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -80,3 +80,5 @@ objects:
         namespace: ${NAMESPACE}
         annotations:
           olm.operatorframework.io/exclude-global-namespace-resolution: 'true'
+      spec:
+        upgradeStrategy: TechPreviewUnsafeFailForward


### PR DESCRIPTION
This sets the Upgrade Strategy to Fail Forward. 

Ref: https://olm.operatorframework.io/docs/advanced-tasks/unsafe-fail-forward-upgrades/