### PR TITLE
Fix Route Monitor Operator with missing security fields

### DIFF
--- a/osde2e/route_monitor_operator_tests.go
+++ b/osde2e/route_monitor_operator_tests.go
@@ -87,6 +87,10 @@ var _ = Describe("Route Monitor Operator", Ordered, func() {
 	It("required dependent resources are created", func(ctx context.Context) {
 		By("Creating a pod, service and route to monitor with a ServiceMonitor and PrometheusRule")
 		By("Creating the test pod")
+		var allowPrivilegeEscalation *bool = new(bool)
+		*allowPrivilegeEscalation = false
+		var runAsNonRoot *bool = new(bool)
+		*runAsNonRoot = true
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      routeMonitorName,
@@ -98,13 +102,13 @@ var _ = Describe("Route Monitor Operator", Ordered, func() {
 						Name:  "test",
 						Image: "quay.io/jitesoft/nginx:mainline",
 						SecurityContext: &corev1.SecurityContext{
-                    					AllowPrivilegeEscalation: pointer.BoolPtr(false),
-                    					Capabilities: &corev1.Capabilities{
-                        					Drop: []corev1.Capability{"ALL"},
-                   				 	},
-                    					RunAsNonRoot: pointer.BoolPtr(true),
-                    					SeccompProfile: &corev1.SeccompProfile{
-                        					Type: corev1.SeccompProfileTypeRuntimeDefault,
+							AllowPrivilegeEscalation: allowPrivilegeEscalation,
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot: runAsNonRoot,
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
 							},
 						},
 					},

--- a/osde2e/route_monitor_operator_tests.go
+++ b/osde2e/route_monitor_operator_tests.go
@@ -97,6 +97,16 @@ var _ = Describe("Route Monitor Operator", Ordered, func() {
 					{
 						Name:  "test",
 						Image: "quay.io/jitesoft/nginx:mainline",
+						SecurityContext: &corev1.SecurityContext{
+                    					AllowPrivilegeEscalation: pointer.BoolPtr(false),
+                    					Capabilities: &corev1.Capabilities{
+                        					Drop: []corev1.Capability{"ALL"},
+                   				 	},
+                    					RunAsNonRoot: pointer.BoolPtr(true),
+                    					SeccompProfile: &corev1.SeccompProfile{
+                        					Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
What type of PR is this?
Part of [OSD-26388](https://issues.redhat.com//browse/OSD-26388)

What this PR does / why we need it?
This PR addresses missing security-related fields for the Route Monitor Operator in the test setup. According to Brady, the failure encountered is due to a few missing security-related fields that need to be configured correctly for the test to succeed.

Which Jira/Github issue(s) this PR fixes?
This PR aims to resolve the issue where missing security-related fields in the test configuration cause failures for the Route Monitor Operator.

Special notes for your reviewer:

The security-related fields have been added as per the test requirements.
Validated the changes with appropriate tests to ensure the setup is correct.

Pre-checks (if applicable):

Verified missing security fields and updated the configuration.
Ran the test to confirm successful setup and resolution of the failure.