### PR TITLE
config/templates: remove base replaces

### DIFF
--- a/config/templates/csv-template.yaml
+++ b/config/templates/csv-template.yaml
@@ -50,5 +50,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  replaces: route-monitor-operator.v0.1.183-e9011b0
   version: 0.0.1


### PR DESCRIPTION
I have a suspicion this is causing a problem in the olm bundle
generation, versions up to 183 are still in the bundle when they
shouldn't be.

Signed-off-by: Brady Pratt <bpratt@redhat.com>
