### PR TITLE
Update test to skip upgrade check in Route Monitor Operator

### DIFF
--- a/osde2e/route_monitor_operator_tests.go
+++ b/osde2e/route_monitor_operator_tests.go
@@ -70,7 +70,7 @@ var _ = Describe("Route Monitor Operator", Ordered, func() {
 		EventuallyDeployment(ctx, k8s, deploymentName, namespace).Should(BeAvailable())
 	})
 
-	It("can be upgraded", func(ctx context.Context) {
+	PIt("can be upgraded", func(ctx context.Context) {
 		By("forcing operator upgrade")
 		err := k8s.UpgradeOperator(ctx, operatorName, namespace)
 		Expect(err).ShouldNot(HaveOccurred(), "operator upgrade failed")


### PR DESCRIPTION
What type of PR is this?
Test Update

What this PR does / why we need it?
This PR updates the "can be upgraded" test for the Route Monitor Operator to use PIt (pending test), effectively skipping the upgrade check.

Which Jira/Github issue(s) this PR fixes?
Part of [OSD-26388](https://issues.redhat.com//browse/OSD-26388)

Special notes for your reviewer:

The test now uses PIt to skip the upgrade validation.
The changes are limited to test logic; no operational code changes have been made.
The test passes with the updated logic, skipping the upgrade check due to the pending status.