### PR TITLE
Add AVO VPC Endpoint Permissions and Handle Additional VPC Endpoint Statuses

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -233,3 +233,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - avo.openshift.io
+  resources:
+  - vpcendpoints
+  verbs:
+  - get
+  - list
+  - watch
+

--- a/controllers/hostedcontrolplane/hostedcontrolplane_test.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane_test.go
@@ -1105,7 +1105,6 @@ func TestDeployDynatraceHTTPMonitorResources(t *testing.T) {
 func TestIsVpcEndpointReady(t *testing.T) {
 	tests := []struct {
 		name              string
-		vpcEndpointName   string
 		vpcEndpointStatus string
 		expectedResult    bool
 		expectedError     bool
@@ -1117,8 +1116,20 @@ func TestIsVpcEndpointReady(t *testing.T) {
 			expectedError:     false,
 		},
 		{
-			name:              "VpcEndpoint is not available",
+			name:              "VpcEndpoint is pending",
 			vpcEndpointStatus: "pending",
+			expectedResult:    false,
+			expectedError:     false, // Pending is not an error, just not ready
+		},
+		{
+			name:              "VpcEndpoint is rejected",
+			vpcEndpointStatus: "rejected",
+			expectedResult:    false,
+			expectedError:     true,
+		},
+		{
+			name:              "VpcEndpoint is failed",
+			vpcEndpointStatus: "failed",
 			expectedResult:    false,
 			expectedError:     true,
 		},
@@ -1142,7 +1153,6 @@ func TestIsVpcEndpointReady(t *testing.T) {
 					Namespace: "default",
 				},
 			}
-
 
 			r := newTestReconciler(t)
 			ctx := context.Background()

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -235,3 +235,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - avo.openshift.io
+    resources:
+      - vpcendpoints
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
- Adds permission for RMO controller to fetch vpc endpoint 
- Improved handling of additional VPC endpoint statuses 

Follow up of https://github.com/openshift/route-monitor-operator/pull/343
Ticket - https://issues.redhat.com/browse/OSD-26967