### PR TITLE
Set applyBehavior to CreateOrUpdate

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -32,6 +32,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
+    applyBehavior: CreateOrUpdate
     resources:
     - apiVersion: v1
       kind: Namespace


### PR DESCRIPTION
# Overview

We are working on a SPIKE to figure out why we continue to have operator install conflicts between HIVE and OLM.
It was suggested that we try changing the default apply mode to `CreateOrUpdate`. 

By default hive will perform the equivalent of a `kubectl apply` when syncing a SSS. Swapping to the `CreateOrUpdate` mode will update hive to perform a `kubectl patch` - and this will hopefully prevent the issues we've been seeing. 

(A in depth explanation can be found here: https://issues.redhat.com/browse/HIVE-2666?focusedId=26162937&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26162937 )

As this issue is not easily reproduced we would like to deploy this change to our non-production clusters and validate if things improve then re-evaluate if we will be promoting this into production. 

# Fixes
- https://issues.redhat.com/browse/OSD-28836 