### PR TITLE
re-enable return when monitor found

### DIFF
--- a/controllers/hostedcontrolplane/hostedcontrolplane.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane.go
@@ -579,7 +579,7 @@ func (r *HostedControlPlaneReconciler) deployDynatraceHttpMonitorResources(ctx c
 	}
 	if exists {
 		log.Info(fmt.Sprintf("HTTP monitor label found. Skipping creating a monitor for %s", monitorName))
-		// return nil
+		return nil
 	}
 
 	clusterId := hostedcontrolplane.Spec.ClusterID


### PR DESCRIPTION
## Overview 

When trying to debug why our non-production environments had an explosion in Synthetic monitors, it was found the `return` statement as part of `checkHttpMonitorExists` was mistakenly commented out during some linting cleanup. This PR re-adds the needed `return`.

## Testing

- Built and pushed to my quay
- swapped out RMO on `hs-mc-n1j3kghkg` to run on my  image
- Deleted monitors in DT (to give headroom for the 5k max monitors error)
- Monitored that there was NO explosion in monitors

### Test findings

The version deployed today is showing the "Found a Monitor" and "Created a Monitor" log:
```
{"level":"info","ts":"2025-05-09T19:47:05Z","logger":"controllers.HostedControlPlane.Reconcile","msg":"HTTP monitor label found. Skipping creating a monitor for ecambel-int-5.dgcj.i3.devshift.org","name":"ecambel-int-5","namespace":"ocm-int-2il6m6a5mlolqbt8l1fvp90185ha8g04-ecambel-int-5"}

{"level":"info","ts":"2025-05-09T19:47:06Z","logger":"controllers.HostedControlPlane.Reconcile","msg":"Created HTTP monitor ","name":"ecambel-int-5","namespace":"ocm-int-2il6m6a5mlolqbt8l1fvp90185ha8g04-ecambel-int-5","HTTP_CHECK-4CB0F9389137E106":"c77aa0fc-405d-414b-affd-e396661c4e2e"}
```

My test version only shows the "Found a Monitor" 
```
{"level":"info","ts":"2025-05-09T20:10:48Z","logger":"controllers.HostedControlPlane.Reconcile","msg":"HTTP monitor label found. Skipping creating a monitor for ecambel-int-5.dgcj.i3.devshift.org","name":"ecambel-int-5","namespace":"ocm-int-2il6m6a5mlolqbt8l1fvp90185ha8g04-ecambel-int-5"}
```