### PR TITLE
update ubi base image to the latest available.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@ RUN make go-build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295.1749680713
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1752068421
 WORKDIR /
 COPY --from=builder /workspace/build/_output/bin/* /manager
 USER nonroot:nonroot


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-1095

Resolves high vulnerabilities. 
https://quay.io/repository/erosente_openshift/rmo_test?tab=tags
