### PR TITLE
SREP-1574 - Probe HCP kube-apiservers with https instead of http to avoid timeouts

### DIFF
--- a/controllers/hostedcontrolplane/healthcheck.go
+++ b/controllers/hostedcontrolplane/healthcheck.go
@@ -159,6 +159,9 @@ func (r *HostedControlPlaneReconciler) addHealthCheckSuccess(ctx context.Context
 	successes := healthcheckConfigMapSuccesses(configmap)
 	successes++
 
+	if configmap.Annotations == nil {
+		configmap.Annotations = map[string]string{}
+	}
 	configmap.Annotations[healthcheckAnnotation] = fmt.Sprintf("%d", successes)
 	err := r.Update(ctx, &configmap)
 	return configmap, err
@@ -172,7 +175,7 @@ func healthcheckHostedControlPlane(hostedcontrolplane *hypershiftv1beta1.HostedC
 		return fmt.Errorf("missing .Status.ControlPlaneEndpoint.Host")
 	}
 
-	url := fmt.Sprintf("http://%s/livez", controlplaneEndpoint)
+	url := fmt.Sprintf("https://%s/livez", controlplaneEndpoint)
 	return endpointOK(url)
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-1574

---

Updates RMO's initial HCP healthchecking logic to use https instead of http. Using http to GET the kube-apiservers' `/livez` endpoint always fails with a timeout, regardless if the cluster is healthy or not. 

Additionally, fixes a panic in the configmap-update logic if the configmap's annotations are not yet defined. 