### PR TITLE
Increase code coverage to 60%

### DIFF
--- a/pkg/alert/prometheusrule_test.go
+++ b/pkg/alert/prometheusrule_test.go
@@ -199,4 +199,16 @@ var _ = Describe("CR Deployment Handling", func() {
 			})
 		})
 	})
+
+	Describe("NewPrometheusRule", func() {
+		It("should create a PrometheusRule with correct properties", func() {
+			client := mockClient
+			ctx := context.Background()
+			result := alert.NewPrometheusRule(ctx, client)
+
+			Expect(result.Client).To(Equal(client))
+			Expect(result.Ctx).To(Equal(ctx))
+			Expect(result.Comparer).NotTo(BeNil())
+		})
+	})
 })

--- a/pkg/reconcile/common_test.go
+++ b/pkg/reconcile/common_test.go
@@ -388,4 +388,68 @@ var _ = Describe("CR Deployment Handling", func() {
 			})
 		})
 	})
+
+	Describe("NewMonitorResourceCommon", func() {
+		It("should create a MonitorResourceCommon with correct properties", func() {
+			client := mockClient
+			ctx := context.Background()
+			result := reconcilecommon.NewMonitorResourceCommon(ctx, client)
+
+			Expect(result.Client).To(Equal(client))
+			Expect(result.Ctx).To(Equal(ctx))
+			Expect(result.Comparer).NotTo(BeNil())
+		})
+	})
+
+	Describe("ResourceComparer", func() {
+		var comparer reconcilecommon.ResourceComparer
+
+		Describe("DeepEqual", func() {
+			It("should return true for equal values", func() {
+				result := comparer.DeepEqual("test", "test")
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return false for different values", func() {
+				result := comparer.DeepEqual("test1", "test2")
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return true for equal structs", func() {
+				struct1 := v1alpha1.RouteMonitor{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+				struct2 := v1alpha1.RouteMonitor{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+				result := comparer.DeepEqual(struct1, struct2)
+				Expect(result).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("GetOSDClusterID", func() {
+		When("ClusterVersion not found", func() {
+			BeforeEach(func() {
+				get.CalledTimes = 1
+				get.ErrorResponse = consterror.NotFoundErr
+			})
+			It("should return error", func() {
+				result, err := rc.GetOSDClusterID()
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(Equal(""))
+			})
+		})
+	})
+
+	Describe("GetServiceMonitor", func() {
+		When("ServiceMonitor not found", func() {
+			BeforeEach(func() {
+				get.CalledTimes = 1
+				get.ErrorResponse = consterror.NotFoundErr
+			})
+			It("should return error", func() {
+				namespacedName := types.NamespacedName{Name: "test", Namespace: "test"}
+				result, err := rc.GetServiceMonitor(namespacedName)
+				Expect(err).To(HaveOccurred())
+				Expect(result).NotTo(BeNil()) // It returns an empty ServiceMonitor, not nil
+			})
+		})
+	})
 })

--- a/pkg/util/reconcile/reconcile_wrapper_suite_test.go
+++ b/pkg/util/reconcile/reconcile_wrapper_suite_test.go
@@ -1,0 +1,14 @@
+package reconcile_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestReconcileWrapper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ReconcileWrapper Suite")
+}
+

--- a/pkg/util/reconcile/reconcile_wrapper_test.go
+++ b/pkg/util/reconcile/reconcile_wrapper_test.go
@@ -1,0 +1,127 @@
+package reconcile_test
+
+import (
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/openshift/route-monitor-operator/pkg/util/reconcile"
+)
+
+var _ = Describe("ReconcileWrapper", func() {
+
+	Describe("Result.Convert", func() {
+		It("should convert Result to ctrl.Result correctly", func() {
+			result := reconcile.Result{
+				Requeue:      true,
+				RequeueAfter: 5 * time.Second,
+				Continue:     false,
+			}
+
+			ctrlResult := result.Convert()
+
+			Expect(ctrlResult.Requeue).To(BeTrue())
+			Expect(ctrlResult.RequeueAfter).To(Equal(5 * time.Second))
+		})
+	})
+
+	Describe("Result.ReturnWith", func() {
+		It("should return ctrl.Result and error", func() {
+			result := reconcile.Result{
+				Requeue:      true,
+				RequeueAfter: 5 * time.Second,
+			}
+			testError := errors.New("test error")
+
+			ctrlResult, err := result.ReturnWith(testError)
+
+			Expect(ctrlResult.Requeue).To(BeTrue())
+			Expect(ctrlResult.RequeueAfter).To(Equal(5 * time.Second))
+			Expect(err).To(Equal(testError))
+		})
+	})
+
+	Describe("Stop", func() {
+		It("should return empty ctrl.Result and no error", func() {
+			ctrlResult, err := reconcile.Stop()
+
+			Expect(ctrlResult).To(Equal(ctrl.Result{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("RequeueWith", func() {
+		It("should return empty ctrl.Result and the provided error", func() {
+			testError := errors.New("test error")
+
+			ctrlResult, err := reconcile.RequeueWith(testError)
+
+			Expect(ctrlResult).To(Equal(ctrl.Result{}))
+			Expect(err).To(Equal(testError))
+		})
+	})
+
+	Describe("Requeue", func() {
+		It("should return ctrl.Result with Requeue true and no error", func() {
+			ctrlResult, err := reconcile.Requeue()
+
+			Expect(ctrlResult.Requeue).To(BeTrue())
+			Expect(ctrlResult.RequeueAfter).To(Equal(time.Duration(0)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("RequeueAfter", func() {
+		It("should return ctrl.Result with RequeueAfter set", func() {
+			duration := 10 * time.Second
+
+			ctrlResult := reconcile.RequeueAfter(duration)
+
+			Expect(ctrlResult.RequeueAfter).To(Equal(duration))
+			Expect(ctrlResult.Requeue).To(BeFalse())
+		})
+	})
+
+	Describe("Result.RequeueOrStop", func() {
+		It("should return true when Requeue is true", func() {
+			result := reconcile.Result{Requeue: true, Continue: false}
+			Expect(result.RequeueOrStop()).To(BeTrue())
+		})
+
+		It("should return true when Continue is false", func() {
+			result := reconcile.Result{Requeue: false, Continue: false}
+			Expect(result.RequeueOrStop()).To(BeTrue())
+		})
+
+		It("should return false when Requeue is false and Continue is true", func() {
+			result := reconcile.Result{Requeue: false, Continue: true}
+			Expect(result.RequeueOrStop()).To(BeFalse())
+		})
+	})
+
+	Describe("Result.ShouldStop", func() {
+		It("should return true when Continue is false", func() {
+			result := reconcile.Result{Continue: false}
+			Expect(result.ShouldStop()).To(BeTrue())
+		})
+
+		It("should return false when Continue is true", func() {
+			result := reconcile.Result{Continue: true}
+			Expect(result.ShouldStop()).To(BeFalse())
+		})
+	})
+
+	Describe("RequeueReconcile", func() {
+		It("should return Result with Requeue true and no error", func() {
+			result, err := reconcile.RequeueReconcile()
+
+			Expect(result.Requeue).To(BeTrue())
+			Expect(result.Continue).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+


### PR DESCRIPTION
Add test coverage for key components:

- BlackBox Exporter: Add tests for constructor, namespace getter, config map management, and resource cleanup functions
- ServiceMonitor: Add tests for constructor, template functions, HyperShift deployment, and resource creation
- Reconcile utilities: Add tests for ResourceComparer.DeepEqual, MonitorResourceCommon constructor, cluster ID retrieval
- Alert: Add test for NewPrometheusRule constructor
- Reconcile wrapper: Add new test suite covering Result conversion, stopping, requeueing, and utility functions