### PR TITLE
SREP-1624 - Check age of cluster first when determining if HCP cluster ready

### DIFF
--- a/controllers/hostedcontrolplane/healthcheck.go
+++ b/controllers/hostedcontrolplane/healthcheck.go
@@ -58,6 +58,10 @@ const (
 // "routemonitor.managed.openshift.io/successful-healthchecks" can be added-to/edited-on the configmap with a large number (ie - 999) to bypass
 // this functionality
 func (r *HostedControlPlaneReconciler) hcpReady(ctx context.Context, hostedcontrolplane *hypershiftv1beta1.HostedControlPlane) error {
+	if checkClusterOver1Hour(hostedcontrolplane.CreationTimestamp) {
+		return nil
+	}
+
 	healthcheckConfigMap, err := r.getHealthCheckConfigMap(ctx, hostedcontrolplane)
 	if err != nil {
 		if !kerr.IsNotFound(err) {
@@ -94,10 +98,6 @@ func (r *HostedControlPlaneReconciler) hcpReady(ctx context.Context, hostedcontr
 
 	successes = healthcheckConfigMapSuccesses(healthcheckConfigMap)
 	if successes >= consecutiveSuccessfulHealthchecks {
-		return nil
-	}
-
-	if checkClusterOver1Hour(hostedcontrolplane.CreationTimestamp) {
 		return nil
 	}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-1624

---

Re-organizes the HCP healthchecking logic slightly to automatically return ready if a cluster is >1h old, regardless of the reachability of it's kube-apiserver.