### PR TITLE
SREP-834 Add Probe API URL Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ To support this, the operator [takes into account](https://github.com/openshift/
 
 Currently the blackbox exporter deployment is only using the default config file which only allows a limit set of probes.
 
+## Configuration
+
+### Probe API URL (Experimental)
+
+For RHOBS synthetics integration with HostedCluster monitoring, configure the probe API URL:
+
+```bash
+--probe-api-url="https://observatorium.api.openshift.com/api/metrics/v1/probes"
+```
+
+When empty (default), uses standard blackbox exporter behavior.
+
 ## Development
 
 In order to develop the repo follow these steps to get an env started:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,6 +43,7 @@ spec:
             - --zap-log-level=debug
             - --blackbox-image=$(BLACKBOX_IMAGE)
             - --blackbox-namespace=$(BLACKBOX_NAMESPACE)
+            - --probe-api-url=$(PROBE_API_URL)
           env:
             - name: LOG_LEVEL
               # level 1 is debug, so when we want to raise the level we can
@@ -55,6 +56,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PROBE_API_URL
+              value: ""
           image: controller:latest
           name: manager
           securityContext:

--- a/controllers/clusterurlmonitor/clusterurlmonitor.go
+++ b/controllers/clusterurlmonitor/clusterurlmonitor.go
@@ -48,7 +48,7 @@ type ClusterUrlMonitorReconciler struct {
 	Common           controllers.MonitorResourceHandler
 }
 
-func NewReconciler(mgr manager.Manager, blackboxExporterImage, blackboxExporterNamespace string, enablehypershift bool) *ClusterUrlMonitorReconciler {
+func NewReconciler(mgr manager.Manager, blackboxExporterImage, blackboxExporterNamespace string, enablehypershift bool, probeAPIURL string) *ClusterUrlMonitorReconciler {
 	log := ctrl.Log.WithName("controllers").WithName("ClusterUrlMonitor")
 	client := mgr.GetClient()
 	ctx := context.Background()

--- a/controllers/routemonitor/routemonitor.go
+++ b/controllers/routemonitor/routemonitor.go
@@ -48,7 +48,7 @@ type RouteMonitorReconciler struct {
 	Common           controllers.MonitorResourceHandler
 }
 
-func NewReconciler(mgr manager.Manager, blackboxExporterImage, blackboxExporterNamespace string, enablehypershift bool) *RouteMonitorReconciler {
+func NewReconciler(mgr manager.Manager, blackboxExporterImage, blackboxExporterNamespace string, enablehypershift bool, probeAPIURL string) *RouteMonitorReconciler {
 	log := ctrl.Log.WithName("controllers").WithName("RouteMonitor")
 	client := mgr.GetClient()
 	ctx := context.Background()

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -39,6 +39,7 @@ spec:
             - --zap-log-level=debug
             - --blackbox-image=$(BLACKBOX_IMAGE)
             - --blackbox-namespace=$(BLACKBOX_NAMESPACE)
+            - --probe-api-url=$(PROBE_API_URL)
           command:
             - /manager
           env:
@@ -50,6 +51,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PROBE_API_URL
+              value: ""
           image: route-monitor-operator:latest
           livenessProbe:
             httpGet:

--- a/hack/hypershift-package/hypershift-artifacts-template.yaml
+++ b/hack/hypershift-package/hypershift-artifacts-template.yaml
@@ -13,6 +13,9 @@ parameters:
   required: true
 - name: PACKAGE_TAG
   required: true
+- name: PROBE_API_URL
+  value: ""
+  required: false
 
 objects:
 - apiVersion: hive.openshift.io/v1
@@ -71,6 +74,8 @@ objects:
                                   name: route-monitor-operator
                               spec:
                                 image: ${PACKAGE_IMAGE}:${PACKAGE_TAG}
+                                config:
+                                  probeApiUrl: ${PROBE_API_URL}
                       pruneObjectBehavior: DeleteIfCreated
                       remediationAction: enforce
                       severity: low

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -17,6 +17,9 @@ parameters:
 - name: REPO_NAME
   value: route-monitor-operator
   required: true
+- name: PROBE_API_URL
+  value: ""
+  required: false
 
 objects:
 - apiVersion: hive.openshift.io/v1
@@ -83,3 +86,10 @@ objects:
           olm.operatorframework.io/exclude-global-namespace-resolution: 'true'
       spec:
         upgradeStrategy: TechPreviewUnsafeFailForward
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ${REPO_NAME}-config
+        namespace: ${NAMESPACE}
+      data:
+        probe-api-url: ${PROBE_API_URL}

--- a/pkg/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/blackboxexporter/blackboxexporter_test.go
@@ -504,8 +504,6 @@ var _ = Describe("Blackboxexporter", func() {
 		})
 	})
 
-
-
 })
 
 func testPrivateDefaultIC() operatorv1.IngressController {

--- a/pkg/servicemonitor/servicemonitor_test.go
+++ b/pkg/servicemonitor/servicemonitor_test.go
@@ -213,13 +213,13 @@ var _ = Describe("CR Deployment Handling", func() {
 
 	Describe("TemplateAndUpdateServiceMonitorDeployment", func() {
 		var (
-			routeURL                   = "https://example.com"
-			blackBoxExporterNamespace  = "test-namespace"
-			namespacedName             = serviceMonitorRef
-			clusterID                  = "test-cluster"
-			isHCPMonitor               = false
-			useInsecure                = false
-			owner                      *metav1.OwnerReference
+			routeURL                  = "https://example.com"
+			blackBoxExporterNamespace = "test-namespace"
+			namespacedName            = serviceMonitorRef
+			clusterID                 = "test-cluster"
+			isHCPMonitor              = false
+			useInsecure               = false
+			owner                     *metav1.OwnerReference
 		)
 
 		BeforeEach(func() {

--- a/pkg/util/reconcile/reconcile_wrapper_suite_test.go
+++ b/pkg/util/reconcile/reconcile_wrapper_suite_test.go
@@ -11,4 +11,3 @@ func TestReconcileWrapper(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ReconcileWrapper Suite")
 }
-

--- a/pkg/util/reconcile/reconcile_wrapper_test.go
+++ b/pkg/util/reconcile/reconcile_wrapper_test.go
@@ -124,4 +124,3 @@ var _ = Describe("ReconcileWrapper", func() {
 		})
 	})
 })
-


### PR DESCRIPTION
Add configurable probe API URL for RHOBS synthetics:
- Add --probe-api-url flag with empty default
- Update OLM and PKO templates for configuration
- Apply to HyperShift monitoring only