### PR TITLE
SREP-833 Implement RHOBS probe API integration for HCP Synthetics

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func main() {
 	}
 
 	if enableHCP {
-		hostedControlPlaneReconciler := hostedcontrolplane.NewHostedControlPlaneReconciler(mgr)
+		hostedControlPlaneReconciler := hostedcontrolplane.NewHostedControlPlaneReconciler(mgr, probeAPIURL)
 		if err = hostedControlPlaneReconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "HostedControlPlane")
 			os.Exit(1)

--- a/pkg/rhobs/client.go
+++ b/pkg/rhobs/client.go
@@ -1,0 +1,241 @@
+package rhobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	// HTTP client configuration
+	defaultHTTPTimeout = 30 * time.Second
+
+	// HTTP methods
+	httpMethodPost  = "POST"
+	httpMethodGet   = "GET"
+	httpMethodPatch = "PATCH"
+
+	// API endpoint paths
+	probesEndpointPath = "/metrics/probes"
+	probeEndpointPath  = "/metrics/probes/%s"
+
+	// HTTP headers
+	contentTypeJSON = "application/json"
+
+	// Query parameters
+	labelSelectorParam = "label_selector"
+
+	// Log levels
+	debugLogLevel = 2
+
+	// Error message prefixes
+	apiErrorPrefix = "API request failed with status"
+)
+
+// ProbeRequest represents the payload for creating/updating a probe
+type ProbeRequest struct {
+	ClusterID           string `json:"cluster_id"`
+	APIServerURL        string `json:"apiserver_url"`
+	ManagementClusterID string `json:"management_cluster_id,omitempty"`
+	Private             bool   `json:"private"`
+}
+
+// ProbeResponse represents the response from the RHOBS API
+type ProbeResponse struct {
+	ID        string `json:"id"`
+	ClusterID string `json:"cluster_id"`
+	Status    string `json:"status"`
+}
+
+// ProbesListResponse represents the response from GET probes endpoint
+type ProbesListResponse struct {
+	Probes []ProbeResponse `json:"probes"`
+}
+
+// Client handles communication with the RHOBS synthetics API
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	tenant     string
+	logger     logr.Logger
+}
+
+// NewClient creates a new RHOBS API client
+func NewClient(baseURL, tenant string, logger logr.Logger) *Client {
+	return &Client{
+		baseURL: strings.TrimSuffix(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: defaultHTTPTimeout,
+		},
+		tenant: tenant,
+		logger: logger,
+	}
+}
+
+// CreateProbe creates a new probe in RHOBS
+func (c *Client) CreateProbe(ctx context.Context, req ProbeRequest) (*ProbeResponse, error) {
+	url := fmt.Sprintf("%s/%s%s", c.baseURL, c.tenant, probesEndpointPath)
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal probe request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, httpMethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", contentTypeJSON)
+
+	c.logger.V(debugLogLevel).Info("Creating RHOBS probe", "url", url, "cluster_id", req.ClusterID)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("%s %d: %s", apiErrorPrefix, resp.StatusCode, string(body))
+	}
+
+	var probeResp ProbeResponse
+	if err := json.Unmarshal(body, &probeResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &probeResp, nil
+}
+
+// GetProbe retrieves a probe by cluster ID
+func (c *Client) GetProbe(ctx context.Context, clusterID string) (*ProbeResponse, error) {
+	url := fmt.Sprintf("%s/%s%s", c.baseURL, c.tenant, probesEndpointPath)
+
+	httpReq, err := http.NewRequestWithContext(ctx, httpMethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	// Add label_selector query parameter for cluster_id
+	q := httpReq.URL.Query()
+	q.Add(labelSelectorParam, fmt.Sprintf("cluster_id=%s", clusterID))
+	httpReq.URL.RawQuery = q.Encode()
+
+	c.logger.V(debugLogLevel).Info("Getting RHOBS probe", "url", httpReq.URL.String(), "cluster_id", clusterID)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil // Probe doesn't exist
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s %d: %s", apiErrorPrefix, resp.StatusCode, string(body))
+	}
+
+	var listResp ProbesListResponse
+	if err := json.Unmarshal(body, &listResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Find the probe with matching cluster_id
+	for _, probe := range listResp.Probes {
+		if probe.ClusterID == clusterID {
+			return &probe, nil
+		}
+	}
+
+	return nil, nil // Probe not found
+}
+
+// ProbePatchRequest represents the payload for updating a probe status
+type ProbePatchRequest struct {
+	Status string `json:"status"`
+}
+
+// DeleteProbe marks a probe for termination by cluster ID using PATCH method
+func (c *Client) DeleteProbe(ctx context.Context, clusterID string) error {
+	// First check if probe exists and get its current state
+	existingProbe, err := c.GetProbe(ctx, clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to check existing probe: %w", err)
+	}
+
+	if existingProbe == nil {
+		// Probe doesn't exist, consider this success
+		c.logger.V(debugLogLevel).Info("Probe not found, nothing to delete", "cluster_id", clusterID)
+		return nil
+	}
+
+	// Handle failed probes by recreating them in terminating state
+	if existingProbe.Status == "failed" {
+		c.logger.Info("Probe is in failed state, will recreate in terminating state", "cluster_id", clusterID, "probe_id", existingProbe.ID)
+		// Note: Actual probe deletion will be handled by agents
+	}
+
+	url := fmt.Sprintf("%s/%s"+probeEndpointPath, c.baseURL, c.tenant, clusterID)
+
+	// Create patch request to set status to terminating
+	patchReq := ProbePatchRequest{
+		Status: "terminating",
+	}
+
+	payload, err := json.Marshal(patchReq)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, httpMethodPatch, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", contentTypeJSON)
+
+	c.logger.V(debugLogLevel).Info("Terminating RHOBS probe", "url", url, "cluster_id", clusterID)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		// Probe already doesn't exist, consider this success
+		return nil
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s %d: %s", apiErrorPrefix, resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// IsNon200Error checks if an error represents a non-200 HTTP status
+func IsNon200Error(err error) bool {
+	return err != nil && strings.Contains(err.Error(), apiErrorPrefix)
+}

--- a/pkg/rhobs/client_test.go
+++ b/pkg/rhobs/client_test.go
@@ -1,0 +1,650 @@
+package rhobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+)
+
+func TestCreateProbe(t *testing.T) {
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Expected POST method, got %s", r.Method)
+		}
+
+		if r.URL.Path != "/test-tenant/metrics/probes" {
+			t.Errorf("Expected path /test-tenant/metrics/probes, got %s", r.URL.Path)
+		}
+
+		var req ProbeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+
+		if req.ClusterID != "test-cluster" {
+			t.Errorf("Expected cluster_id test-cluster, got %s", req.ClusterID)
+		}
+
+		// Return a mock response
+		resp := ProbeResponse{
+			ID:        "probe-123",
+			ClusterID: "test-cluster",
+			Status:    "active",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// Create client
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	// Test create probe
+	probeReq := ProbeRequest{
+		ClusterID:    "test-cluster",
+		APIServerURL: "https://api.test-cluster.example.com/livez",
+		Private:      false,
+	}
+
+	probe, err := client.CreateProbe(context.Background(), probeReq)
+	if err != nil {
+		t.Fatalf("CreateProbe failed: %v", err)
+	}
+
+	if probe.ID != "probe-123" {
+		t.Errorf("Expected probe ID probe-123, got %s", probe.ID)
+	}
+}
+
+func TestGetProbe(t *testing.T) {
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Expected GET method, got %s", r.Method)
+		}
+
+		labelSelector := r.URL.Query().Get("label_selector")
+		expectedSelector := "cluster_id=test-cluster"
+		if labelSelector != expectedSelector {
+			t.Errorf("Expected label_selector %s, got %s", expectedSelector, labelSelector)
+		}
+
+		// Return a mock response
+		resp := ProbesListResponse{
+			Probes: []ProbeResponse{
+				{
+					ID:        "probe-123",
+					ClusterID: "test-cluster",
+					Status:    "active",
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// Create client
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	// Test get probe
+	probe, err := client.GetProbe(context.Background(), "test-cluster")
+	if err != nil {
+		t.Fatalf("GetProbe failed: %v", err)
+	}
+
+	if probe == nil {
+		t.Fatal("Expected probe to be found, got nil")
+	}
+
+	if probe.ID != "probe-123" {
+		t.Errorf("Expected probe ID probe-123, got %s", probe.ID)
+	}
+}
+
+func TestDeleteProbe(t *testing.T) {
+	// First call to GetProbe to check existing probe
+	getCallCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			getCallCount++
+			// Return existing probe on first call
+			resp := ProbesListResponse{
+				Probes: []ProbeResponse{
+					{
+						ID:        "probe-123",
+						ClusterID: "test-cluster",
+						Status:    "active",
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if r.Method != "PATCH" {
+			t.Errorf("Expected PATCH method, got %s", r.Method)
+		}
+
+		if r.URL.Path != "/test-tenant/metrics/probes/test-cluster" {
+			t.Errorf("Expected path /test-tenant/metrics/probes/test-cluster, got %s", r.URL.Path)
+		}
+
+		// Verify PATCH payload
+		var req ProbePatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode PATCH request: %v", err)
+		}
+
+		if req.Status != "terminating" {
+			t.Errorf("Expected status 'terminating', got %s", req.Status)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create client
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	// Test delete probe
+	err := client.DeleteProbe(context.Background(), "test-cluster")
+	if err != nil {
+		t.Fatalf("DeleteProbe failed: %v", err)
+	}
+
+	if getCallCount != 1 {
+		t.Errorf("Expected 1 GET call, got %d", getCallCount)
+	}
+}
+
+func TestCreateProbe_Errors(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		expectedError string
+	}{
+		{
+			name:          "server error",
+			statusCode:    http.StatusInternalServerError,
+			responseBody:  "Internal Server Error",
+			expectedError: "API request failed with status 500",
+		},
+		{
+			name:          "bad request",
+			statusCode:    http.StatusBadRequest,
+			responseBody:  "Bad Request",
+			expectedError: "API request failed with status 400",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL, "test-tenant", testr.New(t))
+			probeReq := ProbeRequest{
+				ClusterID:    "test-cluster",
+				APIServerURL: "https://api.test-cluster.example.com/livez",
+				Private:      false,
+			}
+
+			_, err := client.CreateProbe(context.Background(), probeReq)
+			if err == nil {
+				t.Fatal("Expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("Expected error to contain %q, got %q", tt.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+func TestCreateProbe_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("invalid json"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+	probeReq := ProbeRequest{
+		ClusterID:    "test-cluster",
+		APIServerURL: "https://api.test-cluster.example.com/livez",
+		Private:      false,
+	}
+
+	_, err := client.CreateProbe(context.Background(), probeReq)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to unmarshal response") {
+		t.Errorf("Expected unmarshal error, got %q", err.Error())
+	}
+}
+
+func TestGetProbe_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	probe, err := client.GetProbe(context.Background(), "non-existent-cluster")
+	if err != nil {
+		t.Fatalf("GetProbe failed: %v", err)
+	}
+
+	if probe != nil {
+		t.Error("Expected nil probe for 404 response")
+	}
+}
+
+func TestGetProbe_EmptyList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ProbesListResponse{
+			Probes: []ProbeResponse{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	probe, err := client.GetProbe(context.Background(), "test-cluster")
+	if err != nil {
+		t.Fatalf("GetProbe failed: %v", err)
+	}
+
+	if probe != nil {
+		t.Error("Expected nil probe for empty list")
+	}
+}
+
+func TestGetProbe_NoMatchingCluster(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ProbesListResponse{
+			Probes: []ProbeResponse{
+				{
+					ID:        "probe-123",
+					ClusterID: "different-cluster",
+					Status:    "active",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	probe, err := client.GetProbe(context.Background(), "test-cluster")
+	if err != nil {
+		t.Fatalf("GetProbe failed: %v", err)
+	}
+
+	if probe != nil {
+		t.Error("Expected nil probe when no matching cluster_id")
+	}
+}
+
+func TestGetProbe_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	_, err := client.GetProbe(context.Background(), "test-cluster")
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "API request failed with status 500") {
+		t.Errorf("Expected status error, got %q", err.Error())
+	}
+}
+
+func TestGetProbe_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("invalid json"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	_, err := client.GetProbe(context.Background(), "test-cluster")
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to unmarshal response") {
+		t.Errorf("Expected unmarshal error, got %q", err.Error())
+	}
+}
+
+func TestDeleteProbe_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			// Return empty list (probe not found)
+			resp := ProbesListResponse{
+				Probes: []ProbeResponse{},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	err := client.DeleteProbe(context.Background(), "non-existent-cluster")
+	if err != nil {
+		t.Fatalf("DeleteProbe should succeed when probe doesn't exist, got error: %v", err)
+	}
+}
+
+func TestDeleteProbe_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			// Return existing probe
+			resp := ProbesListResponse{
+				Probes: []ProbeResponse{
+					{
+						ID:        "probe-123",
+						ClusterID: "test-cluster",
+						Status:    "active",
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	err := client.DeleteProbe(context.Background(), "test-cluster")
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "API request failed with status 500") {
+		t.Errorf("Expected status error, got %q", err.Error())
+	}
+}
+
+func TestIsNon200Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-API error",
+			err:      http.ErrUseLastResponse,
+			expected: false,
+		},
+		{
+			name:     "API error with status code",
+			err:      fmt.Errorf("API request failed with status 400: Bad Request"),
+			expected: true,
+		},
+		{
+			name:     "other error with API text",
+			err:      fmt.Errorf("some other API request failed with status in message"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsNon200Error(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsNon200Error() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCreateProbe_NetworkError(t *testing.T) {
+	// Use invalid URL to trigger HTTP client error
+	client := NewClient("http://invalid-host-12345.invalid", "test-tenant", testr.New(t))
+	probeReq := ProbeRequest{
+		ClusterID:    "test-cluster",
+		APIServerURL: "https://api.test-cluster.example.com/livez",
+		Private:      false,
+	}
+
+	_, err := client.CreateProbe(context.Background(), probeReq)
+	if err == nil {
+		t.Fatal("Expected network error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to send HTTP request") {
+		t.Errorf("Expected network error, got %q", err.Error())
+	}
+}
+
+func TestGetProbe_NetworkError(t *testing.T) {
+	// Use invalid URL to trigger HTTP client error
+	client := NewClient("http://invalid-host-12345.invalid", "test-tenant", testr.New(t))
+
+	_, err := client.GetProbe(context.Background(), "test-cluster")
+	if err == nil {
+		t.Fatal("Expected network error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to send HTTP request") {
+		t.Errorf("Expected network error, got %q", err.Error())
+	}
+}
+
+func TestDeleteProbe_NetworkError(t *testing.T) {
+	// Use invalid URL to trigger HTTP client error
+	client := NewClient("http://invalid-host-12345.invalid", "test-tenant", testr.New(t))
+
+	err := client.DeleteProbe(context.Background(), "test-cluster")
+	if err == nil {
+		t.Fatal("Expected network error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to check existing probe") {
+		t.Errorf("Expected check error, got %q", err.Error())
+	}
+}
+
+func TestDeleteProbe_FailedProbeHandling(t *testing.T) {
+	// Test that failed probes are handled appropriately
+	getCallCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			getCallCount++
+			// Return failed probe on first call
+			resp := ProbesListResponse{
+				Probes: []ProbeResponse{
+					{
+						ID:        "probe-123",
+						ClusterID: "test-cluster",
+						Status:    "failed",
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if r.Method != "PATCH" {
+			t.Errorf("Expected PATCH method, got %s", r.Method)
+		}
+
+		// Verify PATCH payload
+		var req ProbePatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode PATCH request: %v", err)
+		}
+
+		if req.Status != "terminating" {
+			t.Errorf("Expected status 'terminating', got %s", req.Status)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create client
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	// Test delete probe with failed status
+	err := client.DeleteProbe(context.Background(), "test-cluster")
+	if err != nil {
+		t.Fatalf("DeleteProbe failed: %v", err)
+	}
+
+	if getCallCount != 1 {
+		t.Errorf("Expected 1 GET call, got %d", getCallCount)
+	}
+}
+
+func TestDeleteProbe_GetProbeError(t *testing.T) {
+	// Test error handling when GetProbe fails
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("Get error"))
+			return
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	err := client.DeleteProbe(context.Background(), "test-cluster")
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to check existing probe") {
+		t.Errorf("Expected check error, got %q", err.Error())
+	}
+}
+
+func TestDeleteProbe_PatchError(t *testing.T) {
+	// Test error handling when PATCH fails
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			// Return existing probe
+			resp := ProbesListResponse{
+				Probes: []ProbeResponse{
+					{
+						ID:        "probe-123",
+						ClusterID: "test-cluster",
+						Status:    "active",
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("PATCH error"))
+			return
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	err := client.DeleteProbe(context.Background(), "test-cluster")
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "API request failed with status 400") {
+		t.Errorf("Expected PATCH error, got %q", err.Error())
+	}
+}
+
+func TestGetProbe_LabelSelectorFormat(t *testing.T) {
+	// Test that label_selector parameter is properly formatted
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Expected GET method, got %s", r.Method)
+		}
+
+		labelSelector := r.URL.Query().Get("label_selector")
+		if labelSelector != "cluster_id=my-cluster-123" {
+			t.Errorf("Expected label_selector 'cluster_id=my-cluster-123', got '%s'", labelSelector)
+		}
+
+		// Return empty list
+		resp := ProbesListResponse{
+			Probes: []ProbeResponse{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-tenant", testr.New(t))
+
+	// Test with cluster ID that contains hyphens and numbers
+	probe, err := client.GetProbe(context.Background(), "my-cluster-123")
+	if err != nil {
+		t.Fatalf("GetProbe failed: %v", err)
+	}
+
+	if probe != nil {
+		t.Error("Expected nil probe for empty list")
+	}
+}
+
+// APIError represents an API error for testing
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
[SREP-833](https://issues.redhat.com//browse/SREP-833) Implement RHOBS probe API integration for HostedControlPlane monitoring

- Add RHOBS API client for synthetics probe management
- Integrate RHOBS probe creation/deletion in HostedControlPlane controller
- Support GET validation for existing probes before creation
- Implement RequeueAfter on non-200 API responses for resilience
- Add secure POST/DELETE API calls to /{tenant}/metrics/probes endpoints
- Enable RHOBS integration when --probe-api-url flag or PROBE_API_URL is configured