### PR TITLE
[SREP-833] Add ConfigMap support

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -86,6 +86,30 @@ objects:
           olm.operatorframework.io/exclude-global-namespace-resolution: 'true'
       spec:
         upgradeStrategy: TechPreviewUnsafeFailForward
+
+###############################################################################
+# Hypershift (MC-only) Configuration
+###############################################################################
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: route-monitor-operator-config
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+        - key: ext-hypershift.openshift.io/cluster-type
+          operator: In
+          values:
+            - "management-cluster"
+    resourceApplyMode: Sync
+    applyBehavior: CreateOrUpdate
+    resources:
     - apiVersion: v1
       kind: ConfigMap
       metadata:


### PR DESCRIPTION
Add ConfigMap support
- Add ConfigMap reading functionality for probe-api-url configuration
- Update OLM template for MC-only configuration deployment

This ensures the operator can read probe API URL from the route-monitor-operator-config ConfigMap as specified in the OLM deployment template, while maintaining backward compatibility with command-line flag configuration.