### PR TITLE
Implement OIDC authentication support for RHOBS probe API

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -20,6 +20,15 @@ parameters:
 - name: PROBE_API_URL
   value: ""
   required: false
+- name: OIDC_CLIENT_ID
+  value: ""
+  required: false
+- name: OIDC_CLIENT_SECRET
+  value: ""
+  required: false
+- name: OIDC_ISSUER_URL
+  value: ""
+  required: false
 
 objects:
 - apiVersion: hive.openshift.io/v1
@@ -117,3 +126,6 @@ objects:
         namespace: ${NAMESPACE}
       data:
         probe-api-url: ${PROBE_API_URL}
+        oidc-client-id: ${OIDC_CLIENT_ID}
+        oidc-client-secret: ${OIDC_CLIENT_SECRET}
+        oidc-issuer-url: ${OIDC_ISSUER_URL}


### PR DESCRIPTION
Add OIDC authentication capabilities to enable secure communication with the RHOBS synthetics probe API using OAuth 2.0 client credentials flow.

- Add OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, and OIDC_ISSUER_URL parameters
- OAuth 2.0 client credentials flow implementation
- Automatic JWT token support
- Automatic OIDC client creation when credentials are available
- Fallback to non-authenticated client when OIDC not configured

Tested successfully locally using Red Hat SSO as the issuer.