### PR TITLE
Make RHOBS tenant configurable to fix 404 API errors

### DIFF
--- a/controllers/hostedcontrolplane/hostedcontrolplane.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane.go
@@ -77,6 +77,7 @@ var logger logr.Logger = ctrl.Log.WithName("controllers").WithName("HostedContro
 // RHOBSConfig holds RHOBS API configuration
 type RHOBSConfig struct {
 	ProbeAPIURL      string
+	Tenant           string
 	OIDCClientID     string
 	OIDCClientSecret string
 	OIDCIssuerURL    string
@@ -750,10 +751,10 @@ func (r *HostedControlPlaneReconciler) createRHOBSClient(log logr.Logger) *rhobs
 			IssuerURL:    r.RHOBSConfig.OIDCIssuerURL,
 		}
 		log.V(2).Info("Creating RHOBS client with OIDC authentication")
-		// Use the OIDC client ID as the tenant name for compatibility with server expectations
-		return rhobs.NewClientWithOIDC(r.RHOBSConfig.ProbeAPIURL, r.RHOBSConfig.OIDCClientID, oidcConfig, log)
+		// Use configurable tenant name in URL path, OIDC client ID is used for authentication headers
+		return rhobs.NewClientWithOIDC(r.RHOBSConfig.ProbeAPIURL, r.RHOBSConfig.Tenant, oidcConfig, log)
 	}
 
 	log.V(2).Info("Creating RHOBS client without authentication")
-	return rhobs.NewClient(r.RHOBSConfig.ProbeAPIURL, "hcp", log)
+	return rhobs.NewClient(r.RHOBSConfig.ProbeAPIURL, r.RHOBSConfig.Tenant, log)
 }


### PR DESCRIPTION
Fixes the "404: no matching operation was found" error by making the RHOBS tenant name configurable instead of using the OIDC client ID.

Changes:
- Add Tenant field to RHOBSConfig struct
- Add --probe-tenant flag with default value "hcp"
- Support probe-tenant in ConfigMap configuration
- Update createRHOBSClient to use configurable tenant for URL path
- OIDC client ID now only used for authentication headers, not URL construction

The tenant name is used in the RHOBS API URL path: /api/metrics/v1/{tenant}/probes

Default behavior uses "hcp" as tenant, but can be customized via:
- Command line: --probe-tenant=your-tenant
- ConfigMap: probe-tenant: "your-tenant"

This maintains backward compatibility while fixing the API endpoint mismatch.