### PR TITLE
fix the PATCH logic to patch the probe ID

### DIFF
--- a/controllers/hostedcontrolplane/hostedcontrolplane.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane.go
@@ -141,6 +141,7 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// Delete RHOBS probe if API URL is configured
 		if r.RHOBSConfig.ProbeAPIURL != "" {
+			log.Info("Attempting to delete RHOBS probe", "cluster_id", hostedcontrolplane.Spec.ClusterID, "probe_api_url", r.RHOBSConfig.ProbeAPIURL)
 			err = r.deleteRHOBSProbe(ctx, log, hostedcontrolplane)
 			if err != nil {
 				log.Error(err, "failed to delete RHOBS probe")

--- a/pkg/rhobs/client.go
+++ b/pkg/rhobs/client.go
@@ -289,7 +289,8 @@ func (c *Client) DeleteProbe(ctx context.Context, clusterID string) error {
 		// Note: Actual probe deletion will be handled by agents
 	}
 
-	url := c.buildProbeURL(clusterID)
+	probeID := existingProbe.ID
+	url := c.buildProbeURL(probeID)
 
 	// Create patch request to set status to terminating
 	patchReq := ProbePatchRequest{
@@ -469,16 +470,16 @@ func (c *Client) buildProbesURL() string {
 }
 
 // buildProbeURL constructs the URL for a specific probe endpoint
-func (c *Client) buildProbeURL(clusterID string) string {
+func (c *Client) buildProbeURL(probeID string) string {
 	// Check if baseURL already contains the probes path
 	if strings.Contains(c.baseURL, "/probes") {
 		// If baseURL ends with /probes, append the cluster ID
 		if strings.HasSuffix(c.baseURL, "/probes") {
-			return fmt.Sprintf("%s/%s", c.baseURL, clusterID)
+			return fmt.Sprintf("%s/%s", c.baseURL, probeID)
 		}
 		// If baseURL contains /probes but doesn't end with it, use as-is and append cluster ID
-		return fmt.Sprintf("%s/%s", c.baseURL, clusterID)
+		return fmt.Sprintf("%s/%s", c.baseURL, probeID)
 	}
 	// Otherwise, build the URL with tenant path and cluster ID
-	return fmt.Sprintf("%s"+probeEndpointPath, c.baseURL, c.tenant, clusterID)
+	return fmt.Sprintf("%s"+probeEndpointPath, c.baseURL, c.tenant, probeID)
 }

--- a/pkg/rhobs/client_test.go
+++ b/pkg/rhobs/client_test.go
@@ -159,8 +159,8 @@ func TestDeleteProbe(t *testing.T) {
 			t.Errorf("Expected PATCH method, got %s", r.Method)
 		}
 
-		if r.URL.Path != "/api/metrics/v1/test-tenant/probes/test-cluster" {
-			t.Errorf("Expected path /api/metrics/v1/test-tenant/probes/test-cluster, got %s", r.URL.Path)
+		if r.URL.Path != "/api/metrics/v1/test-tenant/probes/probe-123" {
+			t.Errorf("Expected path /api/metrics/v1/test-tenant/probes/probe-123, got %s", r.URL.Path)
 		}
 
 		// Verify PATCH payload
@@ -1134,13 +1134,13 @@ func TestFullURLSupportForSpecificProbe(t *testing.T) {
 			name:        "full URL with /probes endpoint for specific probe",
 			baseURL:     "https://rhobs.us-west-2.api.integration.openshift.com/api/metrics/v1/hcp/probes",
 			clusterID:   "test-cluster-123",
-			expectedURL: "https://rhobs.us-west-2.api.integration.openshift.com/api/metrics/v1/hcp/probes/test-cluster-123",
+			expectedURL: "https://rhobs.us-west-2.api.integration.openshift.com/api/metrics/v1/hcp/probes/probe-123",
 		},
 		{
 			name:        "base URL without path for specific probe",
 			baseURL:     "https://rhobs.us-west-2.api.integration.openshift.com",
 			clusterID:   "test-cluster-123",
-			expectedURL: "https://rhobs.us-west-2.api.integration.openshift.com/api/metrics/v1/test-tenant/probes/test-cluster-123",
+			expectedURL: "https://rhobs.us-west-2.api.integration.openshift.com/api/metrics/v1/test-tenant/probes/probe-123",
 		},
 	}
 


### PR DESCRIPTION
# Overview 

This PR fixes the `deleteRHOBSProbe` logic so that when it goes to `PATCH` a probe and put it into `terminating` the URL used uses the **PROBE_ID** vs **CLUSTER_ID**. 

We noticed this issue because all the `PATCH` operations resulted in a 404:
```
{"level":"info","ts":"2025-09-15T10:45:49Z","logger":"controllers.HostedControlPlane.Reconcile","msg":"Sending RHOBS API request","name":"cs-ci-4hb7x","namespace":"ocm-int-2lapgjohvaqtu0m726o0i9bcmflddoeg-cs-ci-4hb7x","method":"PATCH","url":"https://rhobs.us-west-2.api.integration.openshift.com/api/metrics/v1/hcp/probes/5e683985-8526-4e27-a435-d3118ef4afc0","operation":"delete-probe"}
```

Additionally we have a significant amount of `probe_success` metrics in error state (because clusters got deleted but not cleaned up) 