### PR TITLE
[SREP-1909] Fix ConfigMap env vars and add DeleteProbe debugging

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,6 +44,9 @@ spec:
             - --blackbox-image=$(BLACKBOX_IMAGE)
             - --blackbox-namespace=$(BLACKBOX_NAMESPACE)
             - --probe-api-url=$(PROBE_API_URL)
+            - --oidc-client-id=$(OIDC_CLIENT_ID)
+            - --oidc-client-secret=$(OIDC_CLIENT_SECRET)
+            - --oidc-issuer-url=$(OIDC_ISSUER_URL)
           env:
             - name: LOG_LEVEL
               # level 1 is debug, so when we want to raise the level we can
@@ -57,7 +60,29 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: PROBE_API_URL
-              value: ""
+              valueFrom:
+                configMapKeyRef:
+                  name: route-monitor-operator-config
+                  key: probe-api-url
+                  optional: true
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: route-monitor-operator-config
+                  key: oidc-client-id
+                  optional: true
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  name: route-monitor-operator-config
+                  key: oidc-client-secret
+                  optional: true
+            - name: OIDC_ISSUER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: route-monitor-operator-config
+                  key: oidc-issuer-url
+                  optional: true
           image: controller:latest
           name: manager
           securityContext:

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - --blackbox-image=$(BLACKBOX_IMAGE)
             - --blackbox-namespace=$(BLACKBOX_NAMESPACE)
             - --probe-api-url=$(PROBE_API_URL)
+            - --oidc-client-id=$(OIDC_CLIENT_ID)
+            - --oidc-client-secret=$(OIDC_CLIENT_SECRET)
+            - --oidc-issuer-url=$(OIDC_ISSUER_URL)
           command:
             - /manager
           env:
@@ -52,7 +55,29 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: PROBE_API_URL
-              value: ""
+              valueFrom:
+                configMapKeyRef:
+                  key: probe-api-url
+                  name: route-monitor-operator-config
+                  optional: true
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                configMapKeyRef:
+                  key: oidc-client-id
+                  name: route-monitor-operator-config
+                  optional: true
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                configMapKeyRef:
+                  key: oidc-client-secret
+                  name: route-monitor-operator-config
+                  optional: true
+            - name: OIDC_ISSUER_URL
+              valueFrom:
+                configMapKeyRef:
+                  key: oidc-issuer-url
+                  name: route-monitor-operator-config
+                  optional: true
           image: route-monitor-operator:latest
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Configure manager deployment to read PROBE_API_URL and OIDC credentials from the route-monitor-operator-config ConfigMap. Add detailed logging to DeleteProbe method to diagnose why probe termination PATCH requests are not being sent.