### PR TITLE
CNF-23384: mockgen deprecated: use uber-go/mock instead

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.60.0-rhobs1
-	go.uber.org/mock v0.4.0
+	go.uber.org/mock v0.6.0
 	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.32.3
 	k8s.io/apiextensions-apiserver v0.32.2

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
-go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/pkg/reconcile/common_test.go
+++ b/pkg/reconcile/common_test.go
@@ -2,6 +2,7 @@ package reconcileCommon_test
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"

--- a/pkg/util/reconcile/reconcile_wrapper.go
+++ b/pkg/util/reconcile/reconcile_wrapper.go
@@ -1,9 +1,10 @@
 package reconcile
 
 import (
+	"time"
+
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"time"
 )
 
 var Log logr.Logger = ctrl.Log.WithName("ReconcileOperation")

--- a/pkg/util/test/generated/mocks/client/cr-client.go
+++ b/pkg/util/test/generated/mocks/client/cr-client.go
@@ -17,7 +17,6 @@ import (
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	types "k8s.io/apimachinery/pkg/types"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -25,6 +24,7 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
+	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.
@@ -45,10 +45,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockClient) Create(arg0 context.Context, arg1 client.Object, arg2 ...client.CreateOption) error {
+func (m *MockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Create", varargs...)
@@ -57,17 +57,17 @@ func (m *MockClient) Create(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockClientMockRecorder) Create(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Create(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), varargs...)
 }
 
 // Delete mocks base method.
-func (m *MockClient) Delete(arg0 context.Context, arg1 client.Object, arg2 ...client.DeleteOption) error {
+func (m *MockClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Delete", varargs...)
@@ -76,17 +76,17 @@ func (m *MockClient) Delete(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockClientMockRecorder) Delete(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Delete(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), varargs...)
 }
 
 // DeleteAllOf mocks base method.
-func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 client.Object, arg2 ...client.DeleteAllOfOption) error {
+func (m *MockClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "DeleteAllOf", varargs...)
@@ -95,17 +95,17 @@ func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 client.Object, arg2 
 }
 
 // DeleteAllOf indicates an expected call of DeleteAllOf.
-func (mr *MockClientMockRecorder) DeleteAllOf(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteAllOf(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllOf", reflect.TypeOf((*MockClient)(nil).DeleteAllOf), varargs...)
 }
 
 // Get mocks base method.
-func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 client.Object, arg3 ...client.GetOption) error {
+func (m *MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{ctx, key, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Get", varargs...)
@@ -114,47 +114,47 @@ func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 c
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Get(ctx, key, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{ctx, key, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), varargs...)
 }
 
 // GroupVersionKindFor mocks base method.
-func (m *MockClient) GroupVersionKindFor(arg0 runtime.Object) (schema.GroupVersionKind, error) {
+func (m *MockClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GroupVersionKindFor", arg0)
+	ret := m.ctrl.Call(m, "GroupVersionKindFor", obj)
 	ret0, _ := ret[0].(schema.GroupVersionKind)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GroupVersionKindFor indicates an expected call of GroupVersionKindFor.
-func (mr *MockClientMockRecorder) GroupVersionKindFor(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) GroupVersionKindFor(obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupVersionKindFor", reflect.TypeOf((*MockClient)(nil).GroupVersionKindFor), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupVersionKindFor", reflect.TypeOf((*MockClient)(nil).GroupVersionKindFor), obj)
 }
 
 // IsObjectNamespaced mocks base method.
-func (m *MockClient) IsObjectNamespaced(arg0 runtime.Object) (bool, error) {
+func (m *MockClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsObjectNamespaced", arg0)
+	ret := m.ctrl.Call(m, "IsObjectNamespaced", obj)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsObjectNamespaced indicates an expected call of IsObjectNamespaced.
-func (mr *MockClientMockRecorder) IsObjectNamespaced(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) IsObjectNamespaced(obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsObjectNamespaced", reflect.TypeOf((*MockClient)(nil).IsObjectNamespaced), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsObjectNamespaced", reflect.TypeOf((*MockClient)(nil).IsObjectNamespaced), obj)
 }
 
 // List mocks base method.
-func (m *MockClient) List(arg0 context.Context, arg1 client.ObjectList, arg2 ...client.ListOption) error {
+func (m *MockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, list}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "List", varargs...)
@@ -163,17 +163,17 @@ func (m *MockClient) List(arg0 context.Context, arg1 client.ObjectList, arg2 ...
 }
 
 // List indicates an expected call of List.
-func (mr *MockClientMockRecorder) List(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) List(ctx, list any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, list}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
 // Patch mocks base method.
-func (m *MockClient) Patch(arg0 context.Context, arg1 client.Object, arg2 client.Patch, arg3 ...client.PatchOption) error {
+func (m *MockClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{ctx, obj, patch}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Patch", varargs...)
@@ -182,9 +182,9 @@ func (m *MockClient) Patch(arg0 context.Context, arg1 client.Object, arg2 client
 }
 
 // Patch indicates an expected call of Patch.
-func (mr *MockClientMockRecorder) Patch(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Patch(ctx, obj, patch any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{ctx, obj, patch}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockClient)(nil).Patch), varargs...)
 }
 
@@ -231,24 +231,24 @@ func (mr *MockClientMockRecorder) Status() *gomock.Call {
 }
 
 // SubResource mocks base method.
-func (m *MockClient) SubResource(arg0 string) client.SubResourceClient {
+func (m *MockClient) SubResource(subResource string) client.SubResourceClient {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubResource", arg0)
+	ret := m.ctrl.Call(m, "SubResource", subResource)
 	ret0, _ := ret[0].(client.SubResourceClient)
 	return ret0
 }
 
 // SubResource indicates an expected call of SubResource.
-func (mr *MockClientMockRecorder) SubResource(arg0 any) *gomock.Call {
+func (mr *MockClientMockRecorder) SubResource(subResource any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubResource", reflect.TypeOf((*MockClient)(nil).SubResource), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubResource", reflect.TypeOf((*MockClient)(nil).SubResource), subResource)
 }
 
 // Update mocks base method.
-func (m *MockClient) Update(arg0 context.Context, arg1 client.Object, arg2 ...client.UpdateOption) error {
+func (m *MockClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Update", varargs...)
@@ -257,8 +257,8 @@ func (m *MockClient) Update(arg0 context.Context, arg1 client.Object, arg2 ...cl
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockClientMockRecorder) Update(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockClientMockRecorder) Update(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockClient)(nil).Update), varargs...)
 }

--- a/pkg/util/test/generated/mocks/client/status-writer.go
+++ b/pkg/util/test/generated/mocks/client/status-writer.go
@@ -21,6 +21,7 @@ import (
 type MockStatusWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockStatusWriterMockRecorder
+	isgomock struct{}
 }
 
 // MockStatusWriterMockRecorder is the mock recorder for MockStatusWriter.
@@ -41,10 +42,10 @@ func (m *MockStatusWriter) EXPECT() *MockStatusWriterMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockStatusWriter) Create(arg0 context.Context, arg1, arg2 client.Object, arg3 ...client.SubResourceCreateOption) error {
+func (m *MockStatusWriter) Create(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceCreateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{ctx, obj, subResource}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Create", varargs...)
@@ -53,17 +54,17 @@ func (m *MockStatusWriter) Create(arg0 context.Context, arg1, arg2 client.Object
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockStatusWriterMockRecorder) Create(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
+func (mr *MockStatusWriterMockRecorder) Create(ctx, obj, subResource any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{ctx, obj, subResource}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockStatusWriter)(nil).Create), varargs...)
 }
 
 // Patch mocks base method.
-func (m *MockStatusWriter) Patch(arg0 context.Context, arg1 client.Object, arg2 client.Patch, arg3 ...client.SubResourcePatchOption) error {
+func (m *MockStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{ctx, obj, patch}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Patch", varargs...)
@@ -72,17 +73,17 @@ func (m *MockStatusWriter) Patch(arg0 context.Context, arg1 client.Object, arg2 
 }
 
 // Patch indicates an expected call of Patch.
-func (mr *MockStatusWriterMockRecorder) Patch(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
+func (mr *MockStatusWriterMockRecorder) Patch(ctx, obj, patch any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{ctx, obj, patch}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockStatusWriter)(nil).Patch), varargs...)
 }
 
 // Update mocks base method.
-func (m *MockStatusWriter) Update(arg0 context.Context, arg1 client.Object, arg2 ...client.SubResourceUpdateOption) error {
+func (m *MockStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, obj}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Update", varargs...)
@@ -91,8 +92,8 @@ func (m *MockStatusWriter) Update(arg0 context.Context, arg1 client.Object, arg2
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockStatusWriterMockRecorder) Update(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockStatusWriterMockRecorder) Update(ctx, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockStatusWriter)(nil).Update), varargs...)
 }

--- a/pkg/util/test/generated/mocks/controllers/interfaces.go
+++ b/pkg/util/test/generated/mocks/controllers/interfaces.go
@@ -28,6 +28,7 @@ import (
 type MockMonitorResourceHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockMonitorResourceHandlerMockRecorder
+	isgomock struct{}
 }
 
 // MockMonitorResourceHandlerMockRecorder is the mock recorder for MockMonitorResourceHandler.
@@ -198,6 +199,7 @@ func (mr *MockMonitorResourceHandlerMockRecorder) UpdateMonitorResourceStatus(cr
 type MockServiceMonitorHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockServiceMonitorHandlerMockRecorder
+	isgomock struct{}
 }
 
 // MockServiceMonitorHandlerMockRecorder is the mock recorder for MockServiceMonitorHandler.
@@ -277,6 +279,7 @@ func (mr *MockServiceMonitorHandlerMockRecorder) UpdateServiceMonitorDeployment(
 type MockPrometheusRuleHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockPrometheusRuleHandlerMockRecorder
+	isgomock struct{}
 }
 
 // MockPrometheusRuleHandlerMockRecorder is the mock recorder for MockPrometheusRuleHandler.
@@ -328,6 +331,7 @@ func (mr *MockPrometheusRuleHandlerMockRecorder) UpdatePrometheusRuleDeployment(
 type MockBlackBoxExporterHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockBlackBoxExporterHandlerMockRecorder
+	isgomock struct{}
 }
 
 // MockBlackBoxExporterHandlerMockRecorder is the mock recorder for MockBlackBoxExporterHandler.

--- a/pkg/util/test/generated/mocks/reconcile/common.go
+++ b/pkg/util/test/generated/mocks/reconcile/common.go
@@ -19,6 +19,7 @@ import (
 type MockResourceComparerInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourceComparerInterfaceMockRecorder
+	isgomock struct{}
 }
 
 // MockResourceComparerInterfaceMockRecorder is the mock recorder for MockResourceComparerInterface.

--- a/test/e2e/agent_manager.go
+++ b/test/e2e/agent_manager.go
@@ -101,7 +101,7 @@ func (m *AgentManager) startAgent() error {
 	}
 
 	binaryPath := filepath.Join(sourcePath, "rhobs-synthetics-agent")
-	
+
 	cmd := exec.CommandContext(m.Context(), binaryPath, "start", "--config", m.configPath)
 	cmd.Dir = sourcePath
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -43,11 +43,11 @@ type testWriter struct {
 
 func (tw *testWriter) Write(p []byte) (n int, err error) {
 	logLine := string(p)
-	
+
 	// Clean up log formatting: replace tabs with single spaces and remove trailing newlines
 	cleanedLog := strings.ReplaceAll(logLine, "\t", " ")
 	cleanedLog = strings.TrimRight(cleanedLog, "\n")
-	
+
 	tw.t.Log(cleanedLog)
 
 	tw.logMutex.Lock()
@@ -76,12 +76,12 @@ func createProbeViaAPI(baseURL, clusterID, probeURL string, private bool) (strin
 	probeData := map[string]interface{}{
 		"static_url": probeURL,
 		"labels": map[string]string{
-			"cluster-id":   clusterID,
-			"private":      fmt.Sprintf("%t", private),
-			"app":          "rhobs-synthetics-probe",
-			"source":       "route-monitor-operator",
+			"cluster-id":    clusterID,
+			"private":       fmt.Sprintf("%t", private),
+			"app":           "rhobs-synthetics-probe",
+			"source":        "route-monitor-operator",
 			"resource_type": "hostedcontrolplane",
-			"probe_type":   "blackbox",
+			"probe_type":    "blackbox",
 		},
 		"provider": "aws",
 		"region":   "us-east-1",
@@ -297,14 +297,14 @@ func waitForProbeDeletion(baseURL, probeID string, timeout time.Duration) error 
 // This function mocks the agent's behavior for local testing.
 //
 // In a real environment with Kubernetes:
-//   1. Agent fetches probe from API (status: "pending")
-//   2. Agent deploys Prometheus + blackbox-exporter resources to K8s
-//   3. Agent updates probe status to "active" via API
+//  1. Agent fetches probe from API (status: "pending")
+//  2. Agent deploys Prometheus + blackbox-exporter resources to K8s
+//  3. Agent updates probe status to "active" via API
 //
 // In this local test without Kubernetes:
-//   1. Agent fetches probe from API (status: "pending") ✅ Works
-//   2. Agent cannot deploy K8s resources ❌ No cluster
-//   3. Test calls this function to simulate step 3 ✅ Mock
+//  1. Agent fetches probe from API (status: "pending") ✅ Works
+//  2. Agent cannot deploy K8s resources ❌ No cluster
+//  3. Test calls this function to simulate step 3 ✅ Mock
 func updateProbeStatus(baseURL, probeID, status string) error {
 	client := &http.Client{Timeout: 10 * time.Second}
 

--- a/test/e2e/probe_deletion_retry_test.go
+++ b/test/e2e/probe_deletion_retry_test.go
@@ -37,8 +37,8 @@ import (
 //  8. RMO successfully deletes the probe on retry
 //
 // This validates the HYBRID APPROACH:
-//  - Within timeout (15 min): Fail closed - retry and block deletion (prevents orphaned probes)
-//  - Past timeout: Fail open - allow deletion to proceed (prevents indefinite blocking)
+//   - Within timeout (15 min): Fail closed - retry and block deletion (prevents orphaned probes)
+//   - Past timeout: Fail open - allow deletion to proceed (prevents indefinite blocking)
 //
 // REQUIREMENTS:
 // Same as TestFullStackIntegration - needs local RHOBS repos

--- a/test/e2e/process_manager.go
+++ b/test/e2e/process_manager.go
@@ -28,15 +28,15 @@ import (
 
 // ProcessManager provides common functionality for managing external processes
 type ProcessManager struct {
-	name        string
-	cmd         *exec.Cmd
-	sourcePath  string
-	envVarName  string
-	repoName    string
-	stopChan    chan struct{}
-	started     bool
-	ctx         context.Context
-	cancel      context.CancelFunc
+	name       string
+	cmd        *exec.Cmd
+	sourcePath string
+	envVarName string
+	repoName   string
+	stopChan   chan struct{}
+	started    bool
+	ctx        context.Context
+	cancel     context.CancelFunc
 }
 
 // NewProcessManager creates a base process manager
@@ -200,4 +200,3 @@ func (pm *ProcessManager) IsStarted() bool {
 func (pm *ProcessManager) Context() context.Context {
 	return pm.ctx
 }
-

--- a/test/e2e/route_monitor_operator_tests.go
+++ b/test/e2e/route_monitor_operator_tests.go
@@ -924,7 +924,6 @@ func listRHOBSProbes(baseURL, labelSelector string, creds *OIDCCredentials) ([]m
 	return probes, nil
 }
 
-
 // createNamespaceWithCleanup creates a namespace and registers cleanup via DeferCleanup
 func createNamespaceWithCleanup(ctx context.Context, k8s *openshift.Client, namespace string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{
@@ -1348,7 +1347,6 @@ func getOIDCCredentialsFromConfigMap(ctx context.Context, k8s *openshift.Client)
 		ProbeAPIURL:  probeAPIURL,
 	}, nil
 }
-
 
 func getOIDCCredentials(ctx context.Context, environment string) (*OIDCCredentials, error) {
 	// Read credentials from environment variables (must match rmo_secret.yml for CI/CD compatibility)


### PR DESCRIPTION
https://github.com/golang/mock is marked as archived as of `June 27, 2023`.  They recommend using go.uber.org/mock.

This PR attempts to change the dependency to one that is maintained.

The changes to the `generated/` files are because of the new library.

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated mock dependency to a newer version.

* **Style**
  * Improved formatting and alignment across multiple test files.

* **Tests**
  * Added comprehensive test helper infrastructure for end-to-end testing, including resource creation utilities, credential management, and operator bootstrap capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->