### PR TITLE
[SREP-3267] - fix rbac to apply to backplane users.

### DIFF
--- a/deploy_pko/ClusterRole-route-monitor-operator-dedicated-admins-cluster.yaml
+++ b/deploy_pko/ClusterRole-route-monitor-operator-dedicated-admins-cluster.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     managed.openshift.io/aggregate-to-dedicated-admins: "cluster"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: route-monitor-operator-dedicated-admins-cluster
   annotations:
     package-operator.run/phase: rbac

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -31,7 +31,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     resources:
     - apiVersion: v1


### PR DESCRIPTION

With PKO replacing OLM, these CRD-generated ClusterRoles are no longer created, causing backplane users to lose view access to `clusterurlmonitors` and `routemonitors` without elevation.

### Changes

- Added `deploy_pko/ClusterRole-route-monitor-operator-dedicated-admins-cluster.yaml` with:
  - `rbac.authorization.k8s.io/aggregate-to-view: "true"` - restores backplane access via `view` aggregation
  - `managed.openshift.io/aggregate-to-dedicated-admins: "cluster"` - restores dedicated-admin access

### Test plan

- [x] Manually applied ClusterRole to test cluster
- [x] Verified backplane user can `oc get clusterurlmonitors` without elevation
- [x] Verified backplane user can `oc get routemonitors` without elevation