### PR TITLE
[SREP-4347] remove push to master build for rmo pko image.

### DIFF
--- a/.tekton/route-monitor-operator-pko-push.yaml
+++ b/.tekton/route-monitor-operator-pko-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "incoming" && target_branch
       == "master"
   labels:
     appstudio.openshift.io/application: route-monitor-operator


### PR DESCRIPTION
## Summary
Remove the push trigger for `route-monitor-operator-pko` so it only builds via nudge from the e2e component. This is a follow up to https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/16716 

## Problem
The pko build requires the e2e image to exist, but both components were building simultaneously on push to master, causing a race condition where pko would fail if e2e hadn't completed yet.

## Solution
Delete `.tekton/route-monitor-operator-pko-push.yaml` to disable automatic builds on push.

## How it works now
1. Push to master → triggers e2e build (and main operator build)
2. e2e completes successfully → nudges pko to build (via `build-nudges-ref` configured in konflux-release-data)
3. pko builds with e2e image now available

## What still works
- pko builds on pull requests (via `route-monitor-operator-pko-pull-request.yaml`)
- pko builds when nudged by e2e after successful completion