### PR TITLE
Add a bypass to the hcpAvailable check for E2E tests

### DIFF
--- a/controllers/hostedcontrolplane/hostedcontrolplane.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane.go
@@ -286,9 +286,12 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Gate on HCP Available condition to prevent creating probes for
 	// installing clusters. Without this, probes start failing before
 	// the API server is reachable, causing false API SLO Burn alerts.
-	if available, reason := isHCPAvailable(hostedcontrolplane); !available {
-		log.Info("HCP not yet Available, delaying probe deployment", "reason", reason)
-		return utilreconcile.RequeueAfter(healthcheckIntervalSeconds * time.Second), nil
+	// Skip this check for test environments (e.g., osde2e tests without real HCP status)
+	if !rhobsConfig.SkipInfrastructureHealthCheck {
+		if available, reason := isHCPAvailable(hostedcontrolplane); !available {
+			log.Info("HCP not yet Available, delaying probe deployment", "reason", reason)
+			return utilreconcile.RequeueAfter(healthcheckIntervalSeconds * time.Second), nil
+		}
 	}
 
 	// Ensure cluster is ready to be monitored before deploying any probing objects

--- a/controllers/hostedcontrolplane/hostedcontrolplane_test.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane_test.go
@@ -954,10 +954,11 @@ func TestIsHCPAvailable(t *testing.T) {
 
 func TestReconcile_HCPAvailableGate(t *testing.T) {
 	tests := []struct {
-		name                 string
-		conditions           []metav1.Condition
-		expectRequeue        bool
-		expectMonitorObjects bool
+		name                          string
+		conditions                    []metav1.Condition
+		skipInfrastructureHealthCheck bool
+		expectRequeue                 bool
+		expectMonitorObjects          bool
 	}{
 		{
 			name: "HCP not available - should requeue without creating objects",
@@ -969,14 +970,23 @@ func TestReconcile_HCPAvailableGate(t *testing.T) {
 					LastTransitionTime: metav1.Now(),
 				},
 			},
-			expectRequeue:        true,
-			expectMonitorObjects: false,
+			skipInfrastructureHealthCheck: false,
+			expectRequeue:                 true,
+			expectMonitorObjects:          false,
 		},
 		{
-			name:                 "HCP no conditions - should requeue without creating objects",
-			conditions:           nil,
-			expectRequeue:        true,
-			expectMonitorObjects: false,
+			name:                          "HCP no conditions - should requeue without creating objects",
+			conditions:                    nil,
+			skipInfrastructureHealthCheck: false,
+			expectRequeue:                 true,
+			expectMonitorObjects:          false,
+		},
+		{
+			name:                          "HCP no conditions but skip-infrastructure-health-check=true - should bypass Available check",
+			conditions:                    nil,
+			skipInfrastructureHealthCheck: true,
+			expectRequeue:                 false,
+			expectMonitorObjects:          false, // Won't create objects due to missing kube-apiserver service, but won't block on Available
 		},
 	}
 
@@ -1002,6 +1012,10 @@ func TestReconcile_HCPAvailableGate(t *testing.T) {
 			}
 
 			r := newTestReconciler(t, hcp)
+			// Set the RHOBSConfig with SkipInfrastructureHealthCheck if specified
+			r.RHOBSConfig = RHOBSConfig{
+				SkipInfrastructureHealthCheck: tt.skipInfrastructureHealthCheck,
+			}
 
 			result, err := r.Reconcile(context.Background(), ctrl.Request{
 				NamespacedName: types.NamespacedName{


### PR DESCRIPTION
https://github.com/openshift/route-monitor-operator/pull/509/changes added a check to make sure we don't alert on HCP clusters that are not yet available. This is a great change but it breaks our e2e tests which mock HCP clusters and will never become available.

To fix this, I am reusing our "skipInfrastructureHealthcheck" flag for this check and bypassing it when set to true. 