### PR TITLE
SREP-4395: Add TLS reachability check before deploying monitoring

### DIFF
--- a/controllers/hostedcontrolplane/healthcheck.go
+++ b/controllers/hostedcontrolplane/healthcheck.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -231,6 +232,26 @@ func olderThan(obj metav1.Object, age time.Duration) bool {
 	now := time.Now()
 	minCreationTime := now.Add((-1 * age))
 	return obj.GetCreationTimestamp().Time.Before(minCreationTime)
+}
+
+// isKubeAPIServerReachable performs a TLS dial to the kube-apiserver internal service URL
+// to verify the service cert is ready. This runs every reconcile (unlike hcpReady which
+// only runs during the initial healthcheck window) to catch cert issues that appear after
+// initial healthcheck passes, e.g., during upgrade rolling restarts.
+// The port parameter should come from getKubeAPIServerPort to match the RouteMonitor config.
+func isKubeAPIServerReachable(hostedcontrolplane *hypershiftv1beta1.HostedControlPlane, port int64) error {
+	url := fmt.Sprintf("kube-apiserver.%s.svc.cluster.local:%d", hostedcontrolplane.Namespace, port)
+	conn, err := tls.DialWithDialer(
+		&net.Dialer{Timeout: 5 * time.Second},
+		"tcp",
+		url,
+		&tls.Config{InsecureSkipVerify: true}, //nolint:gosec // Required for internal cluster communication
+	)
+	if err != nil {
+		return fmt.Errorf("TLS dial to kube-apiserver failed: %w", err)
+	}
+	conn.Close()
+	return nil
 }
 
 // isVpcEndpointReady checks if the VPC Endpoint associated with the HostedControlPlane is ready.

--- a/controllers/hostedcontrolplane/hostedcontrolplane.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane.go
@@ -312,6 +312,26 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return utilreconcile.RequeueAfter(vpcEndpointRetryTimeout), err
 	}
 
+	// Verify kube-apiserver TLS is reachable before deploying monitoring.
+	// This catches cases where the initial healthcheck passed but TLS
+	// later breaks (e.g., cert reprovisioning during upgrade rolling restarts).
+	// If TLS fails and monitoring objects already exist, delete them so the
+	// blackbox exporter stops probing and generating probe_success=0 data.
+	if !rhobsConfig.SkipInfrastructureHealthCheck {
+		apiServerPort, err := r.getKubeAPIServerPort(ctx, hostedcontrolplane)
+		if err != nil {
+			log.Info("kube-apiserver service not found, delaying monitoring deployment", "error", err.Error())
+			return utilreconcile.RequeueAfter(healthcheckIntervalSeconds * time.Second), nil
+		}
+		if err := isKubeAPIServerReachable(hostedcontrolplane, apiServerPort); err != nil {
+			log.Info("kube-apiserver TLS not ready, removing monitoring objects", "error", err.Error())
+			if deleteErr := r.deleteInternalMonitoringObjects(ctx, log, hostedcontrolplane); deleteErr != nil {
+				return utilreconcile.RequeueWith(fmt.Errorf("failed to remove internal monitoring objects while kube-apiserver TLS is unavailable: %w", deleteErr))
+			}
+			return utilreconcile.RequeueAfter(healthcheckIntervalSeconds * time.Second), nil
+		}
+	}
+
 	// Cluster ready - deploy kube-apiserver monitoring objects
 	log.Info("Deploying internal monitoring objects")
 	err = r.deployInternalMonitoringObjects(ctx, log, hostedcontrolplane, rhobsConfig)
@@ -355,6 +375,20 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{RequeueAfter: periodicReconcileInterval}, err
 }
 
+// getKubeAPIServerPort resolves the kube-apiserver Service port. Used by both the
+// TLS reachability check and RouteMonitor creation to ensure both use the same port.
+func (r *HostedControlPlaneReconciler) getKubeAPIServerPort(ctx context.Context, hostedcontrolplane *hypershiftv1beta1.HostedControlPlane) (int64, error) {
+	apiServerService := corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: "kube-apiserver", Namespace: hostedcontrolplane.Namespace}, &apiServerService)
+	if err != nil {
+		return 0, fmt.Errorf("couldn't query API server service resource: %w", err)
+	}
+	if len(apiServerService.Spec.Ports) > 0 {
+		return int64(apiServerService.Spec.Ports[0].Port), nil
+	}
+	return 6443, nil
+}
+
 // deployInternalMonitoringObjects creates or updates the objects needed to monitor the kube-apiserver using cluster-internal routes
 func (r *HostedControlPlaneReconciler) deployInternalMonitoringObjects(ctx context.Context, log logr.Logger, hostedcontrolplane *hypershiftv1beta1.HostedControlPlane, cfg RHOBSConfig) error {
 	// Skip internal monitoring for test environments (e.g., osde2e tests without real kube-apiserver infrastructure)
@@ -385,15 +419,9 @@ func (r *HostedControlPlaneReconciler) deployInternalMonitoringObjects(ctx conte
 		}
 	}
 
-	// Quick fix to discover the API server port from the service resource
-	apiServerService := corev1.Service{}
-	err = r.Get(ctx, types.NamespacedName{Name: "kube-apiserver", Namespace: hostedcontrolplane.Namespace}, &apiServerService)
+	apiServerPort, err := r.getKubeAPIServerPort(ctx, hostedcontrolplane)
 	if err != nil {
-		return fmt.Errorf("couldn't query API server service resource: %w", err)
-	}
-	apiServerPort := int64(6443)
-	if len(apiServerService.Spec.Ports) > 0 {
-		apiServerPort = int64(apiServerService.Spec.Ports[0].Port)
+		return err
 	}
 
 	// Create or update RouteMonitor object

--- a/controllers/hostedcontrolplane/hostedcontrolplane_test.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane_test.go
@@ -952,6 +952,37 @@ func TestIsHCPAvailable(t *testing.T) {
 	}
 }
 
+func TestIsKubeAPIServerReachable(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		expectErr bool
+	}{
+		{
+			name:      "Unreachable service returns error",
+			namespace: "ocm-nonexistent-namespace",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hcp := &hypershiftv1beta1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: tt.namespace,
+				},
+			}
+			err := isKubeAPIServerReachable(hcp, 6443)
+			if tt.expectErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestReconcile_HCPAvailableGate(t *testing.T) {
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
## Summary

- Adds `isKubeAPIServerReachable()` TLS dial check that runs every reconcile before deploying internal monitoring objects (RouteMonitor + blackbox exporter)
- Unlike the initial healthcheck (which stops after 5 successes), this runs continuously and catches TLS issues that appear after the initial healthcheck passes (e.g., during upgrade rolling restarts or cert reprovisioning)
- Prevents the blackbox exporter from generating `probe_success=0` data for clusters where the internal kube-apiserver service path isn't ready, which triggers false `api-ErrorBudgetBurn` alerts
- Bypassed when `skip-infrastructure-health-check` is set (e2e tests)

Jira: https://redhat.atlassian.net/browse/SREP-4395

## Test plan

- [x] Unit test for `isKubeAPIServerReachable` (unreachable service returns error)
- [ ] Verify new clusters don't get RouteMonitor until TLS handshake succeeds
- [ ] Verify established clusters continue to be monitored normally