### PR TITLE
SREP-4478: Fix PublicAndPrivate detection -- only Private should be private=true

### DIFF
--- a/controllers/hostedcontrolplane/healthcheck.go
+++ b/controllers/hostedcontrolplane/healthcheck.go
@@ -190,10 +190,12 @@ func healthcheckHostedControlPlane(hostedcontrolplane *hypershiftv1beta1.HostedC
 
 	var url string
 	var secure bool
-	// Both Private and PublicAndPrivate clusters have API URLs that resolve
-	// to VPCE endpoints, so use the internal kube-apiserver URL for health checks.
+	// Only Private clusters have API URLs that resolve exclusively to VPCE
+	// endpoints. PublicAndPrivate clusters have externally reachable APIs,
+	// so use the external URL for health checks. Use internal kube-apiserver
+	// URL only for Private clusters.
 	if hostedcontrolplane.Spec.Platform.AWS != nil &&
-		hostedcontrolplane.Spec.Platform.AWS.EndpointAccess != hypershiftv1beta1.Public {
+		hostedcontrolplane.Spec.Platform.AWS.EndpointAccess == hypershiftv1beta1.Private {
 		url = fmt.Sprintf("https://kube-apiserver.%s.svc.cluster.local:6443/livez", hostedcontrolplane.Namespace)
 		secure = false
 	} else {

--- a/controllers/hostedcontrolplane/synthetics.go
+++ b/controllers/hostedcontrolplane/synthetics.go
@@ -275,12 +275,13 @@ func (r *HostedControlPlaneReconciler) ensureRHOBSProbe(ctx context.Context, log
 		return fmt.Errorf("cluster ID is empty")
 	}
 
-	// Determine if cluster is private. Both Private and PublicAndPrivate
-	// clusters have API URLs that resolve to VPCE endpoints, making them
-	// unreachable from RHOBS cell networks. Only Public clusters have
-	// externally reachable API URLs for cell-side probing.
+	// Determine if cluster is private. Only Private clusters have API URLs
+	// that resolve exclusively to VPCE endpoints, making them unreachable
+	// from RHOBS cell networks. PublicAndPrivate clusters have both public
+	// and PrivateLink access, so their APIs ARE externally reachable and
+	// can be probed by the cell-side synthetics-agent.
 	isPrivate := hostedcontrolplane.Spec.Platform.AWS != nil &&
-		hostedcontrolplane.Spec.Platform.AWS.EndpointAccess != hypershiftv1beta1.Public
+		hostedcontrolplane.Spec.Platform.AWS.EndpointAccess == hypershiftv1beta1.Private
 
 	// Check if cluster is in limited support -- delete probe if it exists and skip creation
 	if hostedcontrolplane.Labels["api.openshift.com/limited-support"] == "true" {


### PR DESCRIPTION
## Summary

- Reverts PR #505 logic: `EndpointAccess != Public` -> `EndpointAccess == Private`
- PublicAndPrivate HCPs have publicly reachable APIs and should be probed by cell-side synthetics-agent
- Only truly Private HCPs (VPCE-only) need backplane agent probing
- 478+ PublicAndPrivate HCPs on us-east-1 currently have wrong `private=true` labels
- Fixes both synthetics.go (probe creation) and healthcheck.go (health check URL)

Jira: https://redhat.atlassian.net/browse/SREP-4478

## References
- HyperShift docs: https://hypershift-docs.netlify.app/reference/service-publishing-strategies/
- PublicAndPrivate = API accessible from public internet AND via PrivateLink

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Verify PublicAndPrivate HCPs get private=false probes after deployment
- [ ] Verify cell-side synthetics-agent picks up PublicAndPrivate probes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed health check and monitoring probe endpoint selection logic to properly handle all cluster network access configuration types, improving accuracy of health status reporting for hosted control planes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->