### PR TITLE
Add terminationMessagePolicy and required-scc annotation for OCP 4.21 conformance

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,6 +17,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         control-plane: controller-manager
         app: route-monitor-operator
@@ -77,6 +79,7 @@ spec:
           name: manager
           securityContext:
             allowPrivilegeEscalation: false
+          terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -20,8 +20,8 @@ spec:
   template:
     metadata:
       annotations:
-        package-operator.run/phase: deploy
         openshift.io/required-scc: restricted-v2
+        package-operator.run/phase: deploy
       labels:
         app: route-monitor-operator
         component: operator

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       annotations:
         package-operator.run/phase: deploy
+        openshift.io/required-scc: restricted-v2
       labels:
         app: route-monitor-operator
         component: operator
@@ -91,6 +92,7 @@ spec:
               memory: 20Mi
           securityContext:
             allowPrivilegeEscalation: false
+          terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         runAsNonRoot: true
       serviceAccountName: route-monitor-operator-system

--- a/deploy_pko/Deployment-route-monitor-operator-controller-manager.yaml.gotmpl
+++ b/deploy_pko/Deployment-route-monitor-operator-controller-manager.yaml.gotmpl
@@ -21,6 +21,7 @@ spec:
     metadata:
       annotations:
         package-operator.run/phase: deploy
+        openshift.io/required-scc: restricted-v2
       labels:
         app: route-monitor-operator
         component: operator
@@ -91,6 +92,7 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+        terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         runAsNonRoot: true
       serviceAccountName: route-monitor-operator-system


### PR DESCRIPTION
## Summary

- Adds `terminationMessagePolicy: FallbackToLogsOnError` to the manager container spec in both OLM (`deploy/`) and PKO (`deploy_pko/`) deployment manifests
- Adds `openshift.io/required-scc: restricted-v2` annotation to pod template metadata in both deployment manifests

These are required for OCP 4.21 conformance. The `terminationMessagePolicy` ensures container termination messages capture log output on error, and the `required-scc` annotation explicitly declares the security context constraint the pod needs.

## Test plan

- [ ] Verify YAML is valid and properly indented
- [ ] Deploy to integration and confirm operator starts correctly
- [ ] Confirm `terminationMessagePolicy` appears in pod spec via `oc get pod -o yaml`
- [ ] Confirm `required-scc` annotation appears in pod metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced OpenShift security configuration by enforcing the `restricted-v2` Security Context Constraint across deployment manifests.
  * Improved error handling and logging behavior for container termination messages by updating the termination message policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->