### PR TITLE
[SREP-3267] - Switch SSS from sync to upsert for OLM

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -31,7 +31,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     resources:
     - apiVersion: v1

--- a/hack/olm-registry/rmo-config-template.yaml
+++ b/hack/olm-registry/rmo-config-template.yaml
@@ -77,7 +77,7 @@ objects:
       - key: ext-hypershift.openshift.io/cluster-sector
         operator: In
         values: ${{SECTORS}}
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     enableResourceTemplates: true
     resources:


### PR DESCRIPTION
Switching from Sync to Upsert for SSS so we can cutover to PKO cleanly. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the resource application behavior in SelectorSyncSet configuration from strict sync mode to upsert semantics, allowing for more flexible resource management updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->