### PR TITLE
SREP-4813: URGENT - Add missing CRD fields for PKO deployment (production impact)

### DIFF
--- a/config/crd/bases/monitoring.openshift.io_routemonitors.yaml
+++ b/config/crd/bases/monitoring.openshift.io_routemonitors.yaml
@@ -35,6 +35,9 @@ spec:
             spec:
               description: RouteMonitorSpec defines the desired state of RouteMonitor
               properties:
+                insecureSkipTLSVerify:
+                  default: false
+                  type: boolean
                 route:
                   description: RouteMonitorRouteSpec references the observed Route resource
                   properties:
@@ -44,8 +47,22 @@ spec:
                     namespace:
                       description: Namespace is the namespace of the Route
                       type: string
+                    port:
+                      format: int64
+                      type: integer
+                    suffix:
+                      type: string
                   type: object
+                serviceMonitorType:
+                  default: monitoring.coreos.com
+                  description: ServiceMonitorType dictates the type of ServiceMonitor
+                    the RouteMonitor should create
+                  enum:
+                    - monitoring.coreos.com
+                    - monitoring.rhobs
+                  type: string
                 skipPrometheusRule:
+                  default: false
                   description: SkipPrometheusRule instructs the controller to skip the
                     creation of PrometheusRule CRs. One common use-case for is for alerts
                     that are defined separately, such as for hosted clusters.

--- a/deploy_pko/CustomResourceDefinition-routemonitors.monitoring.openshift.io.yaml
+++ b/deploy_pko/CustomResourceDefinition-routemonitors.monitoring.openshift.io.yaml
@@ -36,6 +36,9 @@ spec:
           spec:
             description: RouteMonitorSpec defines the desired state of RouteMonitor
             properties:
+              insecureSkipTLSVerify:
+                default: false
+                type: boolean
               route:
                 description: RouteMonitorRouteSpec references the observed Route resource
                 properties:
@@ -45,8 +48,22 @@ spec:
                   namespace:
                     description: Namespace is the namespace of the Route
                     type: string
+                  port:
+                    format: int64
+                    type: integer
+                  suffix:
+                    type: string
                 type: object
+              serviceMonitorType:
+                default: monitoring.coreos.com
+                description: ServiceMonitorType dictates the type of ServiceMonitor
+                  the RouteMonitor should create
+                enum:
+                - monitoring.coreos.com
+                - monitoring.rhobs
+                type: string
               skipPrometheusRule:
+                default: false
                 description: SkipPrometheusRule instructs the controller to skip the
                   creation of PrometheusRule CRs. One common use-case for is for alerts
                   that are defined separately, such as for hosted clusters.


### PR DESCRIPTION
## Summary

**URGENT**: PKO-deployed production hive shards (hivep03uw1, hivep04ew2, hivep06uw2, hivep07ue2) have a stale RouteMonitor CRD that silently drops the `serviceMonitorType` field. This breaks `probe_success` metric forwarding from MC blackbox exporters to RHOBS cells.

**Production is currently working by accident** because old `monitoring.rhobs/v1` ServiceMonitors from the OLM era still exist. But:
- New HCPs created after the PKO transition only get `monitoring.coreos.com/v1` SMs (broken)
- If existing HCPs are deleted/recreated, the old working SMs will be lost
- This is a ticking time bomb for SLO monitoring

## Root cause

The `serviceMonitorType` field was added to the Go types in commit `1baa2f1` (Feb 2024), but `config/crd/bases/` was never regenerated. When the PKO migration landed in [PR #494](https://github.com/openshift/route-monitor-operator/pull/494) (SREP-3267, merged March 24 2026), it copied the stale CRD. The OLM CRD in `deploy/crds/` was maintained separately and already had the field.

On PKO-deployed clusters, the API server silently drops `serviceMonitorType: monitoring.rhobs` set by the HCP controller. The RouteMonitor controller then creates `monitoring.coreos.com/v1` ServiceMonitors, which the RHOBS MonitoringStack does not discover.

## Verified on

**Stage** (`hs-mc-c73cnoto0`, main sector):
- Zero `probe_success` in RHOBS Prometheus, zero blackbox scrape targets
- RouteMonitor spec missing `serviceMonitorType`

**Production** (`hs-mc-e3pjgj3h0`, hivep06uw2, PKO deployed 18h ago):
- RouteMonitor spec missing `serviceMonitorType`
- TWO ServiceMonitors per HCP: old `monitoring.rhobs/v1` (22h, OLM leftover, works) + new `monitoring.coreos.com/v1` (18h, PKO era, broken)

## Production deployment status

| Hive Shard | PKO SSS Age | Status |
|---|---|---|
| hivep03uw1 | deployed | Affected |
| hivep04ew2 | deployed | Affected |
| hivep06uw2 | 18h | Verified broken |
| hivep07ue2 | deployed | Affected |
| hivep01ue1, hivep02ue1, hivep05ue1, hivep08ue2 | not deployed | Safe (still OLM) |

## Fix

Adds missing CRD fields (`serviceMonitorType`, `insecureSkipTLSVerify`, `route.port`, `route.suffix`) to both `config/crd/bases/` and `deploy_pko/`.

Found during [ITN-2026-00139](https://web-rca.devshift.net/incident/ITN-2026-00139) investigation.

Jira: https://redhat.atlassian.net/browse/SREP-4813

## Test plan

- [x] Verify CRD fields match `api/v1alpha1/routemonitor_types.go` struct
- [ ] Deploy to a stage MC via PKO, confirm RouteMonitor spec retains `serviceMonitorType: monitoring.rhobs`
- [ ] Confirm RHOBS Prometheus discovers the blackbox ServiceMonitor and scrapes `probe_success`
- [ ] Verify old `monitoring.coreos.com/v1` SMs are cleaned up after fix