### PR TITLE
Fix nil-safety in GetAPIServerHostname and add probe creation logging

### DIFF
--- a/controllers/hostedcontrolplane/synthetics.go
+++ b/controllers/hostedcontrolplane/synthetics.go
@@ -120,7 +120,10 @@ func getDynatraceEquivalentClusterRegionName(clusterRegion string) (string, erro
 func GetAPIServerHostname(hostedcontrolplane *hypershiftv1beta1.HostedControlPlane) (string, error) {
 	for _, service := range hostedcontrolplane.Spec.Services {
 		if service.Service == "APIServer" {
-			return service.Route.Hostname, nil
+			if service.Route != nil && service.Route.Hostname != "" {
+				return service.Route.Hostname, nil
+			}
+			return "", fmt.Errorf("APIServer Route hostname is empty (service type: %s)", service.Type)
 		}
 	}
 	return "", fmt.Errorf("APIServer service not found in the hostedcontrolplane")
@@ -308,6 +311,7 @@ func (r *HostedControlPlaneReconciler) ensureRHOBSProbe(ctx context.Context, log
 	// Get monitoring URL (API server health endpoint in this case)
 	monitoringURL, err := GetAPIServerHostname(hostedcontrolplane)
 	if err != nil {
+		log.Info("Failed to get API server hostname for probe", "cluster_id", clusterID, "error", err.Error())
 		return fmt.Errorf("failed to get API server hostname: %w", err)
 	}
 	monitoringURL = fmt.Sprintf("https://%s/livez", monitoringURL)
@@ -392,6 +396,8 @@ func (r *HostedControlPlaneReconciler) ensureRHOBSProbe(ctx context.Context, log
 
 	// Create probe request with region label for regional filtering
 	probeReq := rhobs.NewClusterProbeRequest(clusterID, monitoringURL, clusterRegion, isPrivate)
+
+	log.Info("Creating new RHOBS probe", "cluster_id", clusterID, "monitoring_url", monitoringURL, "private", isPrivate, "region", clusterRegion)
 
 	// Create the probe
 	probe, err := client.CreateProbe(ctx, probeReq)


### PR DESCRIPTION
## Summary

Fixes a potential nil pointer dereference in `GetAPIServerHostname` and adds diagnostic logging to the probe creation path.

**Problem**: ~60% of clusters on some RHOBS cells have no synthetics-agent probes, causing "No data" in the Grafana Synthetic Monitoring panels. RMO logs show the reconcile completes successfully (GET probe -> 200 empty -> "Finished reconciling") but never calls POST to create the probe.

**Changes**:
1. `GetAPIServerHostname`: Adds nil check for `service.Route` before accessing `Hostname`. For private clusters using NodePort type, Route may be nil.
2. Adds info-level log when hostname resolution fails, so the error is visible in Loki (previously only logged at Error level by the caller, which may be swallowed by controller-runtime panic recovery).
3. Adds info-level "Creating new RHOBS probe" log before `CreateProbe` call, so we can confirm when the create path is actually reached.

**Investigation context**: Checked cluster `cadp01ue1` (private, us-east-1) on MC `hs-mc-39koj380g`. RMO reconciles every 10 min, enters "Deploying RHOBS probe" block (ProbeAPIURL is set), calls GET and gets empty response, but never calls POST. No error logged. The same MC successfully creates probes for other clusters (POST 201). Need the diagnostic logging to determine if the issue is hostname resolution, API rejection, or something else.

## Test plan

- [ ] Deploy to a stage Hive shard and check RMO logs for private clusters
- [ ] Look for "Failed to get API server hostname" or "Creating new RHOBS probe" in logs
- [ ] Verify probe creation resumes for affected clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened API server configuration validation to prevent invalid states.

* **Chores**
  * Added diagnostic logging for probe management operations to improve troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->