### PR TITLE
OCPBUGS-85584: Cross-check LS label against HostedCluster to mitigate stale HCP labels

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -62,6 +62,7 @@ rules:
 - apiGroups:
   - hypershift.openshift.io
   resources:
+  - hostedclusters
   - hostedcontrolplanes
   verbs:
   - get

--- a/controllers/hostedcontrolplane/synthetics.go
+++ b/controllers/hostedcontrolplane/synthetics.go
@@ -286,8 +286,25 @@ func (r *HostedControlPlaneReconciler) ensureRHOBSProbe(ctx context.Context, log
 	isPrivate := hostedcontrolplane.Spec.Platform.AWS != nil &&
 		hostedcontrolplane.Spec.Platform.AWS.EndpointAccess == hypershiftv1beta1.Private
 
-	// Check if cluster is in limited support -- delete probe if it exists and skip creation
+	// Check if cluster is in limited support -- delete probe if it exists and skip creation.
+	// Cross-check the HostedCluster CR label as the source of truth, since the HCP label
+	// can become stale when LS is removed (OCPBUGS-85584: reconcileHostedControlPlane
+	// only does additive label sync, never removes deleted labels).
+	isLimitedSupport := false
 	if hostedcontrolplane.Labels["api.openshift.com/limited-support"] == "true" {
+		hcNamespace := strings.TrimSuffix(hostedcontrolplane.Namespace, "-"+hostedcontrolplane.Name)
+		hc := &hypershiftv1beta1.HostedCluster{}
+		err := r.Get(ctx, types.NamespacedName{Name: hostedcontrolplane.Name, Namespace: hcNamespace}, hc)
+		if err != nil {
+			log.Info("Could not read HostedCluster to verify LS status, trusting HCP label", "cluster_id", clusterID, "error", err.Error())
+			isLimitedSupport = true
+		} else if hc.Labels["api.openshift.com/limited-support"] == "true" {
+			isLimitedSupport = true
+		} else {
+			log.Info("HCP has stale limited-support label (HC label cleared), ignoring", "cluster_id", clusterID)
+		}
+	}
+	if isLimitedSupport {
 		client := r.createRHOBSClient(log, cfg)
 		existingProbe, err := client.GetProbe(ctx, clusterID)
 		if err != nil {

--- a/controllers/hostedcontrolplane/synthetics_test.go
+++ b/controllers/hostedcontrolplane/synthetics_test.go
@@ -707,9 +707,15 @@ func mockRHOBSServer(t *testing.T, getResponse *rhobs.ProbeResponse, getErr bool
 
 // newHCP creates a HostedControlPlane for testing with the given clusterID, region, labels, and endpoint access.
 func newHCP(clusterID, region string, labels map[string]string, endpointAccess hypershiftv1beta1.AWSEndpointAccessType) *hypershiftv1beta1.HostedControlPlane {
+	return newHCPWithMeta(clusterID, region, labels, endpointAccess, "", "")
+}
+
+func newHCPWithMeta(clusterID, region string, labels map[string]string, endpointAccess hypershiftv1beta1.AWSEndpointAccessType, name, namespace string) *hypershiftv1beta1.HostedControlPlane {
 	return &hypershiftv1beta1.HostedControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: labels,
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: hypershiftv1beta1.HostedControlPlaneSpec{
 			ClusterID: clusterID,
@@ -785,14 +791,25 @@ func TestEnsureRHOBSProbe_LimitedSupport(t *testing.T) {
 			server := mockRHOBSServer(t, tt.getResponse, tt.getErr, tt.deleteErr, &requestLog)
 			defer server.Close()
 
-			r := newTestReconciler(t)
-			ctx := context.Background()
-			logger := log.FromContext(ctx)
-
-			hcp := newHCP("test-cluster", "us-east-1",
+			// Create HC with LS label in the parent namespace so cross-check confirms LS
+			hcp := newHCPWithMeta("test-cluster", "us-east-1",
 				map[string]string{"api.openshift.com/limited-support": "true"},
 				hypershiftv1beta1.PublicAndPrivate,
+				"test-hcp", "ocm-production-clusterid-test-hcp",
 			)
+			hc := &hypershiftv1beta1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "ocm-production-clusterid",
+					Labels:    map[string]string{"api.openshift.com/limited-support": "true"},
+				},
+			}
+
+			r := &HostedControlPlaneReconciler{
+				Client: fake.NewFakeClient(hc),
+			}
+			ctx := context.Background()
+			logger := log.FromContext(ctx)
 
 			cfg := RHOBSConfig{
 				ProbeAPIURL: server.URL + "/probes",
@@ -834,6 +851,96 @@ func TestEnsureRHOBSProbe_LimitedSupport(t *testing.T) {
 				t.Error("expected limited-support flow to skip probe creation, but POST request was made")
 			}
 		})
+	}
+}
+
+func TestEnsureRHOBSProbe_StaleLimitedSupportLabel(t *testing.T) {
+	// Test that when HCP has stale LS label but HC does not, RMO ignores the stale label
+	// and proceeds with probe creation (OCPBUGS-85584)
+	var requestLog []string
+	server := mockRHOBSServer(t, nil, false, false, &requestLog)
+	defer server.Close()
+
+	hcp := newHCPWithMeta("test-cluster", "us-east-1",
+		map[string]string{"api.openshift.com/limited-support": "true"},
+		hypershiftv1beta1.PublicAndPrivate,
+		"test-hcp", "ocm-staging-clusterid-test-hcp",
+	)
+	// HC does NOT have the LS label (it was cleared by CS)
+	hc := &hypershiftv1beta1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hcp",
+			Namespace: "ocm-staging-clusterid",
+			Labels:    map[string]string{"api.openshift.com/name": "test-hcp"},
+		},
+	}
+
+	r := &HostedControlPlaneReconciler{
+		Client: fake.NewFakeClient(hc),
+	}
+	ctx := context.Background()
+	logger := log.FromContext(ctx)
+
+	cfg := RHOBSConfig{
+		ProbeAPIURL: server.URL + "/probes",
+		Tenant:      "test-tenant",
+	}
+
+	err := r.ensureRHOBSProbe(ctx, logger, hcp, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have created a probe (POST), not skipped due to stale LS
+	hasPost := false
+	for _, entry := range requestLog {
+		if strings.HasPrefix(entry, "POST") {
+			hasPost = true
+		}
+	}
+	if !hasPost {
+		t.Error("expected probe creation (POST) after detecting stale LS label, but no POST was made")
+	}
+}
+
+func TestEnsureRHOBSProbe_LSLabelHCNotFound(t *testing.T) {
+	// Test fallback: when HC cannot be read, trust the HCP label (safe default)
+	var requestLog []string
+	server := mockRHOBSServer(t, nil, false, false, &requestLog)
+	defer server.Close()
+
+	hcp := newHCPWithMeta("test-cluster", "us-east-1",
+		map[string]string{"api.openshift.com/limited-support": "true"},
+		hypershiftv1beta1.PublicAndPrivate,
+		"test-hcp", "ocm-staging-clusterid-test-hcp",
+	)
+	// No HC created in fake client -- simulates HC not found
+
+	r := &HostedControlPlaneReconciler{
+		Client: fake.NewFakeClient(),
+	}
+	ctx := context.Background()
+	logger := log.FromContext(ctx)
+
+	cfg := RHOBSConfig{
+		ProbeAPIURL: server.URL + "/probes",
+		Tenant:      "test-tenant",
+	}
+
+	err := r.ensureRHOBSProbe(ctx, logger, hcp, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT have created a probe (falls back to trusting HCP label)
+	hasPost := false
+	for _, entry := range requestLog {
+		if strings.HasPrefix(entry, "POST") {
+			hasPost = true
+		}
+	}
+	if hasPost {
+		t.Error("expected LS flow to skip probe creation when HC not found, but POST was made")
 	}
 }
 

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -64,6 +64,7 @@ rules:
   - apiGroups:
       - hypershift.openshift.io
     resources:
+      - hostedclusters
       - hostedcontrolplanes
     verbs:
       - get

--- a/deploy_pko/ClusterRole-route-monitor-operator-manager-role.yaml
+++ b/deploy_pko/ClusterRole-route-monitor-operator-manager-role.yaml
@@ -64,6 +64,7 @@ rules:
 - apiGroups:
   - hypershift.openshift.io
   resources:
+  - hostedclusters
   - hostedcontrolplanes
   verbs:
   - get


### PR DESCRIPTION
## Summary

Mitigates stale `api.openshift.com/limited-support` labels on HostedControlPlane CRs by cross-checking against the HostedCluster CR (source of truth).

## Problem

The HyperShift HostedCluster controller only does additive label sync from HC to HCP ([OCPBUGS-85584](https://redhat.atlassian.net/browse/OCPBUGS-85584), [PR #8507](https://github.com/openshift/hypershift/pull/8507)). When LS is removed via OCM, the label is cleared on the HC but stays on the HCP forever. RMO checks the HCP label and permanently skips probe creation for these clusters.

## Reproduction (stage, 2026-05-13)

Reproduced on `test-hcp-stable-420` (MC `hs-mc-13vnfh7o0`):
1. Removed LS reason via OCM. OCM confirmed 0 LS reasons.
2. HC label: cleared. HCP label: still `"true"`. Never propagated.

## Fix

When the HCP label says `limited-support: "true"`, RMO now looks up the HostedCluster CR in the parent namespace and checks its label:
- If HC also has LS label: cluster is genuinely in LS, skip probe creation (existing behavior)
- If HC does NOT have LS label: HCP label is stale, ignore it and proceed with probe creation
- If HC cannot be read: fall back to trusting the HCP label (safe default)

This is a mitigation in RMO while the upstream HyperShift fix ([PR #8507](https://github.com/openshift/hypershift/pull/8507)) goes through review and deployment.

## Jira

- [OCPBUGS-85584](https://redhat.atlassian.net/browse/OCPBUGS-85584) (upstream HyperShift bug)
- [SREP-4859](https://redhat.atlassian.net/browse/SREP-4859) (downstream probe gap)

## Test plan

- [ ] Deploy to integration (auto from master) and check RMO logs for "HCP has stale limited-support label" messages
- [ ] Verify probes are created for clusters with stale LS labels
- [ ] Verify clusters genuinely in LS still have probes skipped

[OCPBUGS-85584]: https://redhat.atlassian.net/browse/OCPBUGS-85584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCPBUGS-85584]: https://redhat.atlassian.net/browse/OCPBUGS-85584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved probe handling for limited-support cases: reconciler now cross-checks related cluster state, removes stale probes, and avoids creating probes when appropriate.

* **Chores**
  * RBAC expanded to include hosted cluster resources so operators can manage hosted clusters alongside control planes.

* **Tests**
  * Added tests for limited-support edge cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->