### PR TITLE
Add update verb to ConfigMap RBAC for healthcheck

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,6 +23,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - apps

--- a/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
+++ b/deploy/route-monitor-operator-manager-role.ClusterRole.yaml
@@ -25,6 +25,7 @@ rules:
       - delete
       - get
       - list
+      - update
       - watch
   - apiGroups:
       - apps

--- a/deploy_pko/ClusterRole-route-monitor-operator-manager-role.yaml
+++ b/deploy_pko/ClusterRole-route-monitor-operator-manager-role.yaml
@@ -25,6 +25,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - apps


### PR DESCRIPTION
## Summary

Adds `update` verb to the ConfigMap RBAC rule in the ClusterRole. The RMO healthcheck creates and updates a ConfigMap in each HCP namespace to track consecutive successful /livez probes, but the ClusterRole was missing `update`.

## Problem

On stage and integration, RMO logs show:

```
configmaps "<name>-kube-apiserver-rmo-healthcheck" is forbidden:
User "system:serviceaccount:openshift-route-monitor-operator:route-monitor-operator-system"
cannot update resource "configmaps" in API group "" in the namespace "ocm-staging-..."
```

This blocks the entire reconcile loop at the healthcheck step, preventing probe creation for clusters that pass the Available condition gate.

## Fix

Add `update` to the configmaps verb list in:
- `config/rbac/role.yaml`
- `deploy_pko/ClusterRole-route-monitor-operator-manager-role.yaml`
- `deploy/route-monitor-operator-manager-role.ClusterRole.yaml` (generated)

## Test plan

- [x] `make generate` produces no additional diff
- [ ] Deploy to integration and verify healthcheck ConfigMap can be updated
- [ ] Verify probe creation succeeds for clusters that were previously blocked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes permissions to allow the operator to update services and configuration maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->