### PR TITLE
SREP-4417: Add Containerfile.prow for Prow e2e testing

### DIFF
--- a/test/e2e/Containerfile.prow
+++ b/test/e2e/Containerfile.prow
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.21 AS builder
+
+WORKDIR /build
+ENV GOFLAGS=""
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go test ./test/e2e -v -c --tags=osde2e -o /e2e.test
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+COPY --from=builder /e2e.test /usr/local/bin/e2e.test


### PR DESCRIPTION
## Summary

- Add `test/e2e/Containerfile.prow` for building the e2e test binary on ubi-minimal base
- Enables running RMO e2e tests in Prow operator e2e workflows for Sippy visibility
- Uses the same builder image and build command as the existing Dockerfile

## Related

- Release PR: https://github.com/openshift/release/pull/77989
- Boilerplate PR: https://github.com/openshift/boilerplate/pull/739
- Enhancement: https://github.com/openshift-online/rosa-enhancements/pull/51

## Test plan

- [ ] `podman build -f test/e2e/Containerfile.prow .` builds successfully
- [ ] e2e binary exists at `/usr/local/bin/e2e.test` in the built image

Jira: https://redhat.atlassian.net/browse/SREP-4417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced end-to-end test infrastructure with containerized test builds for improved testing consistency and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->