### PR TITLE
fix: add collision-protection annotation to PKO ConfigMap

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -84,14 +84,29 @@ spec:
               #!/bin/sh
               set -euxo pipefail
 
+              ERRORS=""
               NS="openshift-route-monitor-operator"
-              LABEL="operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator"
+              LABEL="operators.coreos.com/route-monitor-operator.${NS}"
 
-              oc -n "$NS" delete csv -l "$LABEL" || true
-              oc -n "$NS" delete sub -l "$LABEL" || true
-              oc -n "$NS" delete installplan -l "$LABEL" || true
-              oc -n "$NS" delete catalogsource route-monitor-operator-registry || true
-              oc -n "$NS" delete operatorgroup route-monitor-operator || true
+              oc -n "$NS" delete csv -l "$LABEL" --timeout=300s --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CSV. "
+
+              oc -n "$NS" delete subscription.operators.coreos.com -l "$LABEL" --timeout=300s --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete Subscription. "
+
+              oc -n "$NS" delete installplan -l "$LABEL" --timeout=300s --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete InstallPlan. "
+
+              oc -n "$NS" delete catalogsource.operators.coreos.com route-monitor-operator-registry --timeout=300s --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CatalogSource. "
+
+              oc -n "$NS" delete operatorgroup route-monitor-operator --timeout=300s --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete OperatorGroup. "
+
+              if [ -n "$ERRORS" ]; then
+                echo "ERROR: OLM cleanup failed, will retry: ${ERRORS}" >&2
+                exit 1
+              fi
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -64,7 +64,7 @@ metadata:
   annotations:
     package-operator.run/phase: cleanup-deploy
 spec:
-  activeDeadlineSeconds: 300
+  backoffLimit: 40
   template:
     metadata:
       annotations:
@@ -72,7 +72,7 @@ spec:
     spec:
       serviceAccountName: olm-cleanup
       priorityClassName: openshift-user-critical
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: delete-csv
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -59,12 +59,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-{{ .config.version }}
   namespace: openshift-route-monitor-operator
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
+  activeDeadlineSeconds: 300
   template:
     metadata:
       annotations:

--- a/deploy_pko/ConfigMap-route-monitor-operator-manager-config.yaml
+++ b/deploy_pko/ConfigMap-route-monitor-operator-manager-config.yaml
@@ -8,5 +8,6 @@ kind: ConfigMap
 metadata:
   annotations:
     package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
   name: route-monitor-operator-manager-config
   namespace: openshift-route-monitor-operator

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -32,7 +32,7 @@ spec:
         image:
           description: Operator image to deploy
           type: string
-          default: None
+          default: ""
         version:
           description: Operator version tag for resource naming
           type: string

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -33,4 +33,10 @@ spec:
           description: Operator image to deploy
           type: string
           default: None
+        version:
+          description: Operator version tag for resource naming
+          type: string
+          default: "0000000"
+          pattern: "^[a-z0-9][a-z0-9.-]*$"
+          maxLength: 51
       type: object

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -49,3 +49,4 @@ objects:
             image: ${PKO_IMAGE}:${IMAGE_TAG}
             config:
               image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
+              version: ${IMAGE_TAG}


### PR DESCRIPTION
## Summary

Three fixes for the RMO PKO migration, applying patterns from CAMO PR #519 and #527:

1. **Add missing `collision-protection: IfNoController` annotation** to the ConfigMap in `deploy_pko/`. Without it, PKO refuses to adopt the OLM-created ConfigMap, causing `ClusterPackage Available=False`.

2. **Use version-suffixed cleanup Job naming** (CAMO PR #519). The static `olm-cleanup` Job name means the Job only runs once — if OLM artifacts get re-synced after the Job completes, subsequent PKO upgrades can't re-trigger cleanup. Version-suffixed names (`olm-cleanup-{{ .config.version }}`) create a new Job per PKO image.

3. **Improve cleanup Job resilience** (CAMO PR #527). Use `backoffLimit: 40` with `restartPolicy: OnFailure` instead of `activeDeadlineSeconds`. Add `--timeout=300s` and `--ignore-not-found=true` to each `oc delete`, accumulate errors and `exit 1` so retries are triggered on script failures.

## Problem

On all phase-3 production hives (hivep01ue1, hivep02ue1, hivep05ue1, hivep08ue2), the ClusterPackage shows:

```
Available=False, Progressing=True
"refusing adoption, object /v1, Kind=ConfigMap
 openshift-route-monitor-operator/route-monitor-operator-manager-config
 not owned by previous revision"
```

Confirmed on 9 MCs across 3 hive shards. Canary/phase-2 hives are unaffected because their OLM cleanup completed before this gap was hit.

The orphaned OLM artifacts (CSV, Subscription, CatalogSource) persist because the cleanup Job already ran and won't re-run with a static name.

## Changes

- `deploy_pko/ConfigMap-route-monitor-operator-manager-config.yaml`: Add `collision-protection: IfNoController`
- `deploy_pko/Cleanup-OLM-Job.yaml` → `.gotmpl`: Version-suffixed Job name (`olm-cleanup-{{ .config.version }}`), remove `collision-protection` from Job, `backoffLimit: 40`, `restartPolicy: OnFailure`
- `deploy_pko/Cleanup-OLM-Job.yaml.gotmpl` script: `--timeout=300s` and `--ignore-not-found=true` on each `oc delete`, error accumulation with `exit 1`, fully-qualified resource types
- `deploy_pko/manifest.yaml`: Add `version` config property (default `"0000000"`, pattern-validated), fix `image` default from `None` to `""`
- `hack/pko/clusterpackage.yaml`: Pass `IMAGE_TAG` as `version` in ClusterPackage config

## Verification

After the fix promotes through the pipeline:
- `oc get clusterpackage route-monitor-operator` → `Available=True`
- `oc get csv -n openshift-route-monitor-operator` → no RMO CSV
- New `olm-cleanup-<version>` Job should appear alongside old completed `olm-cleanup`

## Related

- App-interface !188736: Phase 3e atomic swap (merged)
- CAMO PR #519: Version-based cleanup Job naming (reference implementation)
- CAMO PR #527: Cleanup Job resilience (OnFailure + timeouts)
- [SREP-3267](https://redhat.atlassian.net/browse/SREP-3267): Complete Konflux migration for route-monitor-operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SREP-3267]: https://redhat.atlassian.net/browse/SREP-3267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ