### PR TITLE
ROSAENG-811: Add gangway-bridge for Prow e2e promotion gating

### DIFF
--- a/hack/gangway-bridge/Dockerfile
+++ b/hack/gangway-bridge/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+
+RUN microdnf install -y jq && microdnf clean all
+
+COPY gangway-bridge.sh /usr/local/bin/gangway-bridge
+RUN chmod +x /usr/local/bin/gangway-bridge
+
+USER 1001
+ENTRYPOINT ["/usr/local/bin/gangway-bridge"]

--- a/hack/gangway-bridge/gangway-bridge.sh
+++ b/hack/gangway-bridge/gangway-bridge.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+set -o pipefail
+
+GANGWAY_URL="https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions"
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+TIMEOUT="${TIMEOUT:-3600}"
+CURL_CONNECT_TIMEOUT=10
+CURL_MAX_TIME=30
+MAX_RETRIES=3
+RETRY_WAIT=10
+
+log() {
+    echo -e "\033[1m$(date '+%Y-%m-%dT%H:%M:%S') ${*}\033[0m" >&2
+}
+
+if [[ -z "${JOB_NAME:-}" ]]; then
+    log "ERROR: JOB_NAME is required"
+    exit 1
+fi
+
+if [[ -z "${GANGWAY_TOKEN:-}" ]]; then
+    log "ERROR: GANGWAY_TOKEN is required"
+    exit 1
+fi
+
+log "Triggering Prow job: ${JOB_NAME}"
+log "  Poll interval: ${POLL_INTERVAL}s"
+log "  Timeout: ${TIMEOUT}s"
+
+# Build the request body with optional env overrides.
+# JOB_ENVS is a comma-separated list of KEY=VALUE pairs passed to the Prow job.
+build_request_body() {
+    if [[ -n "${JOB_ENVS:-}" ]]; then
+        local envs_json="{}"
+        IFS=',' read -ra ENV_LIST <<< "${JOB_ENVS}"
+        for entry in "${ENV_LIST[@]}"; do
+            local key="${entry%%=*}"
+            local value="${entry#*=}"
+            envs_json=$(echo "${envs_json}" | jq --arg k "${key}" --arg v "${value}" '. + {($k): $v}')
+        done
+        jq -cn --argjson envs "${envs_json}" '{"job_execution_type": "1", "pod_spec_options": {"envs": $envs}}'
+    else
+        echo '{"job_execution_type": "1"}'
+    fi
+}
+
+REQUEST_BODY=$(build_request_body)
+if [[ -n "${JOB_ENVS:-}" ]]; then
+    log "  Env overrides: $(echo "${JOB_ENVS}" | sed 's/=[^,]*/=***/g')"
+fi
+
+# Trigger the Prow job via Gangway API
+trigger_job() {
+    local response http_code body
+    for attempt in $(seq 1 "${MAX_RETRIES}"); do
+        response=$(curl -sSL --connect-timeout "${CURL_CONNECT_TIMEOUT}" --max-time "${CURL_MAX_TIME}" \
+            -w "\n%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "${REQUEST_BODY}" \
+            "${GANGWAY_URL}/${JOB_NAME}" 2>/dev/null) || true
+
+        http_code=$(echo "${response}" | tail -1)
+        body=$(echo "${response}" | sed '$d')
+
+        if [[ "${http_code}" == "200" ]]; then
+            echo "${body}"
+            return 0
+        fi
+
+        log "Trigger attempt ${attempt}/${MAX_RETRIES} failed (HTTP ${http_code})"
+        if [[ ${attempt} -lt ${MAX_RETRIES} ]]; then
+            sleep ${RETRY_WAIT}
+        fi
+    done
+
+    log "ERROR: Failed to trigger job after ${MAX_RETRIES} attempts (HTTP ${http_code})"
+    return 1
+}
+
+# Query job status via Gangway API
+query_status() {
+    local job_id="$1"
+    curl -sSL --connect-timeout "${CURL_CONNECT_TIMEOUT}" --max-time "${CURL_MAX_TIME}" \
+        -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
+        "${GANGWAY_URL}/${job_id}" 2>/dev/null
+}
+
+# Trigger
+TRIGGER_RESPONSE=$(trigger_job)
+JOB_ID=$(echo "${TRIGGER_RESPONSE}" | jq -r '.id // empty' 2>/dev/null || true)
+
+if [[ -z "${JOB_ID}" ]]; then
+    log "ERROR: Could not extract job ID from trigger response"
+    exit 1
+fi
+
+log "Job triggered successfully"
+log "  Job ID: ${JOB_ID}"
+log "  Prow: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${JOB_ID}"
+
+# Poll for completion
+START_TIME=$(date +%s)
+
+while true; do
+    ELAPSED=$(( $(date +%s) - START_TIME ))
+    if [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
+        log "ERROR: Timeout after ${TIMEOUT}s waiting for job ${JOB_ID}"
+        exit 1
+    fi
+
+    sleep "${POLL_INTERVAL}"
+
+    STATUS_RESPONSE=$(query_status "${JOB_ID}" || echo '{}')
+    JOB_STATUS=$(echo "${STATUS_RESPONSE}" | jq -r '.job_status // "UNKNOWN"' 2>/dev/null || echo "UNKNOWN")
+
+    ELAPSED=$(( $(date +%s) - START_TIME ))
+    log "Status: ${JOB_STATUS} (${ELAPSED}s elapsed)"
+
+    case "${JOB_STATUS}" in
+        SUCCESS)
+            log "Job ${JOB_ID} succeeded"
+            exit 0
+            ;;
+        FAILURE|ABORTED|ERROR)
+            log "Job ${JOB_ID} failed with status: ${JOB_STATUS}"
+            exit 1
+            ;;
+        PENDING|TRIGGERED|UNKNOWN)
+            continue
+            ;;
+        *)
+            log "Unknown status: ${JOB_STATUS}, continuing to poll"
+            ;;
+    esac
+done

--- a/test/e2e/gangway-bridge-template.yml
+++ b/test/e2e/gangway-bridge-template.yml
@@ -1,0 +1,71 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: gangway-bridge-e2e
+parameters:
+  - name: JOB_NAME
+    required: true
+    description: Prow periodic job name to trigger via Gangway
+  - name: POLL_INTERVAL
+    value: "60"
+    description: Seconds between status polls
+  - name: TIMEOUT
+    value: "3600"
+    description: Maximum seconds to wait for job completion
+  - name: JOB_ENVS
+    value: ""
+    description: Comma-separated KEY=VALUE pairs passed to the Prow job (e.g. OCM_LOGIN_ENV=integration)
+  - name: JOBID
+    generate: expression
+    from: "[0-9a-z]{7}"
+  - name: IMAGE_TAG
+    value: ''
+    required: true
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: gangway-bridge-${IMAGE_TAG}-${JOBID}
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 7200
+      template:
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: Never
+          volumes:
+            - name: gangway-token
+              secret:
+                secretName: gangway-api-token
+          containers:
+            - name: gangway-bridge
+              image: quay.io/app-sre/gangway-bridge:${IMAGE_TAG}
+              env:
+                - name: JOB_NAME
+                  value: ${JOB_NAME}
+                - name: GANGWAY_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: gangway-api-token
+                      key: token
+                - name: POLL_INTERVAL
+                  value: ${POLL_INTERVAL}
+                - name: TIMEOUT
+                  value: ${TIMEOUT}
+                - name: JOB_ENVS
+                  value: ${JOB_ENVS}
+              resources:
+                requests:
+                  cpu: "50m"
+                  memory: "64Mi"
+                limits:
+                  cpu: "100m"
+                  memory: "128Mi"
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault


### PR DESCRIPTION
## Summary

Add a generic gangway-bridge container that triggers a Prow periodic job via the Gangway REST API and polls for completion. This replaces the osde2e container in the SAPM e2e pipeline while keeping the same promotion channel gating pattern.

- `hack/gangway-bridge/gangway-bridge.sh`: trigger + poll script (~100 lines)
- `hack/gangway-bridge/Dockerfile`: ubi-minimal with curl + jq
- `test/e2e/gangway-bridge-template.yml`: OpenShift Template for SAPM

The bridge is generic (takes JOB_NAME as env var) and can be reused by any operator.

## Related

- Release PR (periodic job): pending
- Jira: https://redhat.atlassian.net/browse/ROSAENG-811
- PoC PR: https://github.com/openshift/release/pull/77989 (merged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trigger remote periodic jobs, poll execution with retries until completion, and report final status and logs URL.
  * Allow passing additional job environment variables when triggering jobs; enforce configurable poll interval and overall timeout.

* **Chores**
  * Provide a minimal container image to run the bridge tool.
  * Add an OpenShift template for running the bridge with secure runtime defaults and configurable parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->