### PR TITLE
Increase gangway-bridge default timeout to 2h

### DIFF
--- a/test/e2e/gangway-bridge-template.yml
+++ b/test/e2e/gangway-bridge-template.yml
@@ -10,7 +10,7 @@ parameters:
     value: "60"
     description: Seconds between status polls
   - name: TIMEOUT
-    value: "3600"
+    value: "7200"
     description: Maximum seconds to wait for job completion
   - name: JOB_ENVS
     value: ""


### PR DESCRIPTION
## Summary

Bump the default TIMEOUT parameter from 3600s (1h) to 7200s (2h) to match the activeDeadlineSeconds. The Prow e2e job provisions a ROSA cluster which takes ~90 minutes, so 1h was too tight.

Also serves as a pipeline validation for the gangway-bridge integration.

Jira: https://redhat.atlassian.net/browse/ROSAENG-811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated end-to-end test timeout configuration to improve test reliability and reduce timeout-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->