### PR TITLE
Boilerplate: Update to 8fb7c801f68dc7e06e8d2ae138c2a98f0b234b56

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,14 @@
 # =============================================================================
 #
 # INSTALL
-#   pip install pre-commit
-#   pre-commit install
+#   For detailed setup instructions including uv (recommended) and pip,
+#   see: boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+#
+#   Quick start (uv):
+#     uv sync && source .venv/bin/activate && pre-commit install
+#
+#   Quick start (pip):
+#     pip install 'pre-commit==4.6.0' && pre-commit install
 #
 # USAGE
 #   pre-commit run              # staged files only (developer / agent workflow)
@@ -34,6 +40,9 @@
 #   Auto-fix hooks (trailing-whitespace, end-of-file-fixer) will correct
 #   pre-existing violations on the first run. Stage and commit those fixes
 #   separately before day-to-day use.
+#
+#   Fix commits can be excluded from git blame
+#   https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile
 #
 # =============================================================================
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,10 +5,11 @@
 aliases:
   srep-functional-team-aurora:
     - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
-    - luis-falcon
     - reedcort
   srep-functional-team-fedramp:
     - theautoroboto
@@ -80,7 +81,6 @@ aliases:
     - ravitri
   srep-team-leads:
     - rafael-azevedo
-    - iamkirkbater
     - dustman9000
     - bmeng
     - typeid

--- a/boilerplate/_data/last-boilerplate-commit
+++ b/boilerplate/_data/last-boilerplate-commit
@@ -1,1 +1,1 @@
-61dbfdfcfd8ab11f8ccbd58bf1d299c2fa3336dd
+8fb7c801f68dc7e06e8d2ae138c2a98f0b234b56

--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -29,11 +29,13 @@ if [[ "${CONTAINER_ENGINE##*/}" == "podman" ]] && [[ $OSTYPE == *"linux"* ]]; th
 else
     CE_OPTS="${CE_OPTS} -v $REPO_ROOT:$CONTAINER_MOUNT"
 fi
-container_id=$($CONTAINER_ENGINE run -d ${CE_OPTS} $IMAGE_PULL_PATH sleep infinity)
+container_id=$($CONTAINER_ENGINE run --rm -d ${CE_OPTS} $IMAGE_PULL_PATH sleep infinity)
 
 if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then
   err "Couldn't start detached container"
 fi
+
+trap "$CONTAINER_ENGINE stop $container_id >/dev/null 2>&1" EXIT
 
 # Now run our `make` command in it with the right UID and working directory
 args="exec -it -u $(id -u):0 -w $CONTAINER_MOUNT $container_id"
@@ -51,6 +53,9 @@ if [[ $rc -ne 0 ]]; then
     $CONTAINER_ENGINE $args /bin/bash
   fi
 fi
+
+# Disarm the interrupt trap -- normal cleanup handles it from here
+trap - EXIT
 
 # Finally, remove the container
 banner "Cleaning up the container"

--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -5,10 +5,11 @@
 aliases:
   srep-functional-team-aurora:
     - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
-    - luis-falcon
     - reedcort
   srep-functional-team-fedramp:
     - theautoroboto
@@ -80,7 +81,6 @@ aliases:
     - ravitri
   srep-team-leads:
     - rafael-azevedo
-    - iamkirkbater
     - dustman9000
     - bmeng
     - typeid

--- a/boilerplate/openshift/golang-osd-operator/dependabot.yml
+++ b/boilerplate/openshift/golang-osd-operator/dependabot.yml
@@ -5,8 +5,13 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "lgtm"
+      - "approved"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "UTC"
     ignore:
       - dependency-name: "redhat-services-prod/openshift/boilerplate"
         # don't upgrade boilerplate via these means

--- a/boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+++ b/boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
@@ -1,0 +1,123 @@
+# Pre-Commit Hooks Setup Guide
+
+## Installation
+
+### Recommended: Using uv
+
+[uv](https://github.com/astral-sh/uv) is recommended for Python dependency management. It provides dependency locking with package hashes (supply-chain protection), virtual environment management, and is 10-100x faster than pip.
+
+**Install uv:**
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# Via pip
+pip install uv
+```
+
+**First-time setup:**
+```bash
+uv init --bare                    # creates pyproject.toml
+uv add --dev pre-commit==4.6.0    # adds dependency, generates uv.lock
+source .venv/bin/activate         # macOS/Linux (.venv\Scripts\activate on Windows)
+pre-commit install
+```
+
+**Subsequent setup** (when `pyproject.toml` and `uv.lock` exist):
+```bash
+uv sync
+source .venv/bin/activate
+pre-commit install
+```
+
+### Alternative: Using pip
+
+```bash
+pip install 'pre-commit==4.6.0'   # pinned version (Golden Rule 15)
+pre-commit install
+```
+
+Add to `requirements-dev.txt`: `pre-commit==4.6.0`
+
+## First-Time Setup
+
+Run on all files to catch existing issues:
+```bash
+pre-commit run --all-files
+```
+
+Auto-fix hooks will modify files on first run. Stage and commit these separately:
+```bash
+git diff
+git add .
+git commit -m "Fix: Apply pre-commit auto-fixes"
+```
+
+**Exclude fix commits from git blame:**
+```bash
+# Create .git-blame-ignore-revs with commit hashes
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+See [git-blame docs](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile).
+
+## Usage
+
+**Automatic** (runs on `git commit`):
+```bash
+git add <files>
+git commit -m "Message"
+```
+
+**Manual:**
+```bash
+pre-commit run                              # staged files only
+pre-commit run --all-files                  # entire repo
+pre-commit run --files path/to/file         # specific files
+```
+
+**Bypass (use sparingly):**
+```bash
+SKIP=hook-id git commit -m "Message"        # skip one hook
+git commit --no-verify                      # NEVER use (Golden Rule 16)
+```
+
+Rules: Agents never bypass hooks. Security hooks (gitleaks) never bypassable.
+
+## Troubleshooting
+
+**macOS timeout issues:**
+```bash
+brew install coreutils  # provides gtimeout
+```
+
+**Virtual environment not found:**
+```bash
+source .venv/bin/activate
+uv sync
+```
+
+**Hooks not running:**
+```bash
+ls -la .git/hooks/pre-commit  # verify installation
+pre-commit install            # reinstall
+```
+
+**Hook failures:** Read error messages and fix issues:
+- `go-build`: Fix compilation errors
+- `go-mod-tidy`: Run `go mod tidy` and stage go.mod/go.sum
+- `check-yaml`: Fix YAML syntax
+
+## CI Integration
+
+Pre-commit mirrors `ci/prow/lint`. CI is authoritative; pre-commit is developer convenience. All hooks run in CI with same config.
+
+If pre-commit passes but CI fails: `pre-commit autoupdate`
+
+## Resources
+
+- [Pre-Commit Documentation](https://pre-commit.com/)
+- [uv Documentation](https://github.com/astral-sh/uv)

--- a/boilerplate/openshift/golang-osd-operator/olm_pko_migration.py
+++ b/boilerplate/openshift/golang-osd-operator/olm_pko_migration.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import yaml
 
@@ -629,7 +629,7 @@ def write_pko_dockerfile():
             )
         )
 
-def extract_deployment_selector() -> str | None:
+def extract_deployment_selector() -> Optional[str]:
     """
     Extract the clusterDeploymentSelector from hack/olm-registry/olm-artifacts-template.yaml.
 

--- a/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
+++ b/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
@@ -4,8 +4,14 @@
 # =============================================================================
 #
 # INSTALL
-#   pip install pre-commit
-#   pre-commit install
+#   For detailed setup instructions including uv (recommended) and pip,
+#   see: boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+#
+#   Quick start (uv):
+#     uv sync && source .venv/bin/activate && pre-commit install
+#
+#   Quick start (pip):
+#     pip install 'pre-commit==4.6.0' && pre-commit install
 #
 # USAGE
 #   pre-commit run              # staged files only (developer / agent workflow)
@@ -34,6 +40,9 @@
 #   Auto-fix hooks (trailing-whitespace, end-of-file-fixer) will correct
 #   pre-existing violations on the first run. Stage and commit those fixes
 #   separately before day-to-day use.
+#
+#   Fix commits can be excluded from git blame
+#   https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile
 #
 # =============================================================================
 

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -243,8 +243,28 @@ else
 	$(info Did not find 'config/default' - skipping kustomize manifest generation)
 endif
 
+.PHONY: sync-pko-crds
+sync-pko-crds:
+ifneq (,$(wildcard deploy_pko))
+	@if [ -d deploy/crds ]; then \
+		yq_yaml_flag=""; \
+		if $(YQ) --version 2>&1 | grep -qE "^yq [0-9]"; then \
+			yq_yaml_flag="-y"; \
+		fi; \
+		for crd in deploy/crds/*.yaml; do \
+			[ -f "$$crd" ] || continue; \
+			name=$$($(YQ) -r '.metadata.name' "$$crd"); \
+			$(YQ) $$yq_yaml_flag '.metadata.annotations["package-operator.run/phase"] = "crds" | .metadata.annotations["package-operator.run/collision-protection"] = "IfNoController"' \
+				"$$crd" > "deploy_pko/CustomResourceDefinition-$$name.yaml"; \
+			echo "Synced CRD $$name to deploy_pko/"; \
+		done; \
+	fi
+else
+	$(info deploy_pko/ not found - skipping PKO CRD sync)
+endif
+
 .PHONY: generate
-generate: op-generate go-generate openapi-generate manifests
+generate: op-generate go-generate openapi-generate manifests sync-pko-crds
 
 ifeq (${FIPS_ENABLED}, true)
 go-build: ensure-fips

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@ RUN make go-build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778461551
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
 WORKDIR /
 COPY --from=builder /workspace/build/_output/bin/* /manager
 USER nonroot:nonroot

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778461551
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
Conventions:
- openshift/golang-osd-operator: Update
- openshift/golang-osd-e2e: No change
---
https://github.com/openshift/boilerplate/compare/61dbfdfcfd8ab11f8ccbd58bf1d299c2fa3336dd...8fb7c801f68dc7e06e8d2ae138c2a98f0b234b56

commit: 8fb7c801f68dc7e06e8d2ae138c2a98f0b234b56
author: Josh Branham
Remove user no longer in the org

commit: adf5de77e6238d9697351b1030ec7f4c3e793bac
author: Mitali Bhalla
[ROSA-745](https://redhat.atlassian.net/browse/ROSA-745): MintMaker gomod batch + automerge via boilerplate renovate (#748)

Enable grouped gomod manager in shared renovate.json with Mon-Fri 02:00-04:59
UTC batch window; pre-label lgtm/approved on safe patch/minor/digest updates;
major gomod and Tekton updates open for manual review. Add lgtm/approved and
Mon 03:00 UTC schedule to Dependabot docker template.

Co-authored-by: Cursor <cursoragent@cursor.com>

commit: fb6795dfd897e2b42b7d3b9646228812b57d98c8
author: Kirk Bater
remove iamkirkbater from team leads alias

commit: 1d09b759691974be7028624ad761eb25915d344c
author: Christopher Collins
Fix container-make leaving orphaned containers on interruption

Add --rm to the detached container run so it self-removes when stopped.
Add an EXIT trap to stop the container on abnormal exit (Ctrl+C, terminal
close, SIGTERM). Disarm the trap before normal cleanup so the happy path
uses the existing explicit rm -f without a redundant stop.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

commit: e63f1e4045c75dec240c472fa10d34c6d17bb85e
author: red-hat-konflux[bot]
chore(deps): update registry.access.redhat.com/ubi8/ubi-minimal:latest docker digest to 30b786d

Signed-off-by: red-hat-konflux <126015336+red-hat-konflux[bot]@users.noreply.github.com>

commit: 44a1272cb93ca85457f7179a5eb98b578e3ca6c5
author: red-hat-konflux[bot]
chore(deps): update konflux references (#749)

Signed-off-by: red-hat-konflux <126015336+red-hat-konflux[bot]@users.noreply.github.com>
Co-authored-by: red-hat-konflux[bot] <126015336+red-hat-konflux[bot]@users.noreply.github.com>

commit: 3909bdfa084fe68bff714f4d7e764860ada91018
author: MitaliBhalla
Revert "Merge pull request #741 from MitaliBhalla/chore/renovate-gomod-automerge"

This reverts commit b9feed9077bb86729e82a40dc46e9343da59a915, reversing
changes made to 1628663baae4b9c1b7c55ed302a3d9e99376d8c6.

commit: e5238f5ec6979b77e1853198f77fed08ba1713fc
author: MitaliBhalla
Revert "Merge pull request #746 from MitaliBhalla/chore/renovate-gomod-daily-batch"

This reverts commit dd0c8513538cbc8e2c9df5ce3c2053740d733f34, reversing
changes made to bbab1081503624f1e013b398e1cd2a0806b5d834.

commit: 6ccbd825498f0c7c16c9860084c674ded4d2e1e2
author: MitaliBhalla
Pilot: narrow gomod schedule to current UTC hour for testing

Thu 06:00-06:59 UTC (~11:30 AM-12:30 PM IST) so MintMaker can run soon after
merge. Production window 02:00-04:59 Mon-Fri in a follow-up.

Co-authored-by: Cursor <cursoragent@cursor.com>

commit: eff876184ca983751b866c3cad7d7827c72438da
author: MitaliBhalla
Use short Thursday UTC window for MintMaker pilot test

Temporary schedule 06:00-07:59 UTC (Thu) for immediate validation; restore
02:00-04:59 Mon-Fri in a follow-up after pilot sign-off.

Co-authored-by: Cursor <cursoragent@cursor.com>

commit: d621c3a4fc0f200b400683ae744daa6c0296752d
author: MitaliBhalla
Batch MintMaker gomod updates on a UTC weekday schedule

Group patch/minor gomod bumps into one PR per repo and open them only
UTC 02:00-04:59 on weekdays. Keep lgtm/approved for tide automerge;
merge gating relies on Prow required checks (DPP), not a GitHub Action.

Co-authored-by: Cursor <cursoragent@cursor.com>

commit: a8be62527cc4192704c8f0f61a7f82fe287da4c8
author: Andrew Pantuso
feat: add generation logic to propagate CRDs to deploy_pko if present

commit: c7cd213a17e83b13b310d112b2aff882cd1d4d93
author: Christopher Collins
Revert golangci-lint bump to v2.7.2

The Go 1.26 upgrade is no longer needed — downstream operators are
bumping down the kube components version instead. Revert golangci-lint
from v2.12.2 back to v2.7.2. The Python 3.9 compatibility fix from
PR #743 is intentionally preserved.

This reverts the golangci-lint portion of 43f0781.

Created with assistance from Claude 🤖 <claude@anthropic.com>

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Christopher Collins <collins.christopher@gmail.com>

commit: 43f0781250bdbc42890ac475f032296285c59594
author: Christopher Collins
Bump golangci-lint to v2.12.2 for Go 1.26 support (#743)

* Bump golangci-lint to v2.12.2 for Go 1.26 support

Kubernetes v0.36.1 and controller-runtime v0.24.1 declare go 1.26.0
in their go.mod. The previous golangci-lint v2.7.2 was built with
Go 1.25 and refuses to lint code targeting Go 1.26. Bumping to
v2.12.2 (built with Go 1.26) unblocks operators upgrading to these
dependencies.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

* Fix olm_pko_migration.py Python 3.9 compatibility

The `str | None` union type syntax requires Python 3.10+. The
boilerplate container image ships Python 3.9, causing the
08-pko-migration test to fail with TypeError. Use Optional[str]
from typing instead.

Created with assistance from Claude 🤖 <claude@anthropic.com>

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Christopher Collins <collins.christopher@gmail.com>

---------

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

commit: 915fe611bee0958cec3c36f94294c533fcb7c740
author: devppratik
Update pre-commit-yaml

Add docs

shorten the docs

commit: f939c8d8d64f204a337372534003343078ab2341
author: MitaliBhalla
Enable MintMaker automerge for gomod; pre-label Dependabot docker PRs

Extend boilerplate renovate.json so gomod updates get the same automerge
and lgtm/approved labels as Tekton. Keep Dependabot for /build docker;
add lgtm and approved to the golang-osd-operator dependabot.yml template
labels (with ok-to-test and area/dependency). Operators inherit renovate
via extends; dependabot label changes apply on boilerplate-update.

Co-authored-by: Cursor <cursoragent@cursor.com>

commit: 0fd7c667224a7d6987d3af367801d790d815e495
author: red-hat-konflux[bot]
chore(deps): update konflux references

Signed-off-by: red-hat-konflux <126015336+red-hat-konflux[bot]@users.noreply.github.com>

commit: 5c9b1484a283341e2d9aca8300bf97cfc665ca69
author: red-hat-konflux[bot]
chore(deps): update registry.access.redhat.com/ubi8/ubi-minimal:latest docker digest to f0ed531 (#738)

Signed-off-by: red-hat-konflux <126015336+red-hat-konflux[bot]@users.noreply.github.com>
Co-authored-by: red-hat-konflux[bot] <126015336+red-hat-konflux[bot]@users.noreply.github.com>

commit: 203ecbf77405125ef1241944bf08eb1f342c609f
author: red-hat-konflux[bot]
chore(deps): update konflux references (#737)

Signed-off-by: red-hat-konflux <126015336+red-hat-konflux[bot]@users.noreply.github.com>
Co-authored-by: red-hat-konflux[bot] <126015336+red-hat-konflux[bot]@users.noreply.github.com>

commit: bed16abb324583e2d5196368f26adea310f738bd
author: Josh Branham
Update OWNERS_ALIASES

commit: 6e8c892788d166f584d335354c6a01612e14dfe2
author: jdowni000
Adding Justin Downie to srep-functional-team-aurora

commit: dc60b38466460c3b128d21fd569a2a23ca885eef
author: George Adams
Add geowa4 to OWNERS approvers and srep-functional-team-aurora

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ