### PR TITLE
Update boilerplate to latest version

### DIFF
--- a/.tekton/route-monitor-operator-e2e-pull-request.yaml
+++ b/.tekton/route-monitor-operator-e2e-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     - name: url
       value: https://github.com/openshift/boilerplate
     - name: revision
-      value: master
+      value: f7cb59ff422cb43ab0b9b76e06decb2a1cf384c8
     - name: pathInRepo
       value: pipelines/docker-build-oci-ta/pipeline.yaml
 status: {}

--- a/.tekton/route-monitor-operator-e2e-push.yaml
+++ b/.tekton/route-monitor-operator-e2e-push.yaml
@@ -40,7 +40,7 @@ spec:
     - name: url
       value: https://github.com/openshift/boilerplate
     - name: revision
-      value: master
+      value: f7cb59ff422cb43ab0b9b76e06decb2a1cf384c8
     - name: pathInRepo
       value: pipelines/docker-build-oci-ta/pipeline.yaml
 status: {}

--- a/.tekton/route-monitor-operator-pko-pull-request.yaml
+++ b/.tekton/route-monitor-operator-pko-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     - name: url
       value: https://github.com/openshift/boilerplate
     - name: revision
-      value: master
+      value: f7cb59ff422cb43ab0b9b76e06decb2a1cf384c8
     - name: pathInRepo
       value: pipelines/docker-build-oci-ta/pipeline.yaml
 status: {}

--- a/.tekton/route-monitor-operator-pko-push.yaml
+++ b/.tekton/route-monitor-operator-pko-push.yaml
@@ -41,7 +41,7 @@ spec:
     - name: url
       value: https://github.com/openshift/boilerplate
     - name: revision
-      value: master
+      value: f7cb59ff422cb43ab0b9b76e06decb2a1cf384c8
     - name: pathInRepo
       value: pipelines/docker-build-oci-ta/pipeline.yaml
 status: {}

--- a/.tekton/route-monitor-operator-pull-request.yaml
+++ b/.tekton/route-monitor-operator-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     - name: url
       value: https://github.com/openshift/boilerplate
     - name: revision
-      value: master
+      value: f7cb59ff422cb43ab0b9b76e06decb2a1cf384c8
     - name: pathInRepo
       value: pipelines/docker-build-oci-ta/pipeline.yaml
 status: {}

--- a/.tekton/route-monitor-operator-push.yaml
+++ b/.tekton/route-monitor-operator-push.yaml
@@ -40,7 +40,7 @@ spec:
     - name: url
       value: https://github.com/openshift/boilerplate
     - name: revision
-      value: master
+      value: f7cb59ff422cb43ab0b9b76e06decb2a1cf384c8
     - name: pathInRepo
       value: pipelines/docker-build-oci-ta/pipeline.yaml
 status: {}


### PR DESCRIPTION
## Summary
- Update boilerplate framework from commit bae34e3f to 2153c03c
- Bump UBI9 minimal base image from 9.8-1782191395 to 9.8-1782708562 in operator and OLM registry Dockerfiles

## Changes
- `boilerplate/_data/last-boilerplate-commit`: updated to latest boilerplate commit
- `build/Dockerfile`: UBI9 minimal image updated to 9.8-1782708562
- `build/Dockerfile.olm-registry`: UBI9 minimal image updated to 9.8-1782708562

## Validation
- Tests passed: `make container-test` completed successfully (all unit tests passed with kubebuilder envtest assets)
- Build passed: `go build -o /tmp/rmo-build-test .` completed successfully

## References
- Central boilerplate repository: https://github.com/openshift/boilerplate
- Boilerplate commit: 2153c03ccf3b2f6423642f63361d83eca72af6a5

---
Created with assistance from Claude <claude@anthropic.com>

Created using the [rosa-sre-operator-maintenance](https://github.com/openshift-online/rosa-claude-plugins/tree/main/rosa-sre-operator-maintenance) plugin from [rosa-claude-plugins](https://github.com/openshift-online/rosa-claude-plugins)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned the referenced external CI pipeline to a specific commit SHA instead of using a moving branch, improving build and test stability.
  * Applied the same pinned revision consistently across both pull request and push PipelineRuns.
  * Updated all related PipelineRun variants (including e2e and PKO) to use the same fixed pipeline revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->