### PR TITLE
Trigger Konflux rebuild with trusted task digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ make test-integration
 
 * [ ] add option to specify which probes to use
 * [ ] make service monitor use a different interval via modifying a line in the spec of route monitor
+


### PR DESCRIPTION
No-op change to trigger fresh Konflux push builds. The current push-built images on master were built with an untrusted git-clone-oci-ta task digest ([KONFLUX-14655](https://redhat.atlassian.net/browse/KONFLUX-14655) / [KFLUXSPRT-8263](https://redhat.atlassian.net/browse/KFLUXSPRT-8263)), causing EC failures on all PRs. Merging this triggers new push builds with the now-trusted task version.

[KONFLUX-14655]: https://redhat.atlassian.net/browse/KONFLUX-14655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KFLUXSPRT-8263]: https://redhat.atlassian.net/browse/KFLUXSPRT-8263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a small formatting change in the TODO section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->