### PR TITLE
Trigger Konflux rebuild after trusted task fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ make test-integration
 
 * [ ] add option to specify which probes to use
 * [ ] make service monitor use a different interval via modifying a line in the spec of route monitor
+# Trigger Konflux rebuild


### PR DESCRIPTION
No-op change to trigger fresh Konflux PR builds and EC checks. All 3 push builds on master completed successfully with trusted task digests after PR #587 merged. This PR validates that EC passes with the fresh images.

Related: [KONFLUX-14655](https://redhat.atlassian.net/browse/KONFLUX-14655) / [KFLUXSPRT-8263](https://redhat.atlassian.net/browse/KFLUXSPRT-8263)

[KONFLUX-14655]: https://redhat.atlassian.net/browse/KONFLUX-14655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KFLUXSPRT-8263]: https://redhat.atlassian.net/browse/KFLUXSPRT-8263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Trigger Konflux rebuild” item to the end of the ToDo section in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->