### PR TITLE
[Project Darkstar] PSHP-678: Remediate CVE-2026-45447 in route-monitor-operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@ RUN make go-build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1784092902
 WORKDIR /
 COPY --from=builder /workspace/build/_output/bin/* /manager
 USER nonroot:nonroot

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1784092902
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
## Project Darkstar -- Automated CVE Remediation

> **This PR was generated by Project Darkstar**, an automated CVE remediation tool.
> For questions or concerns, contact **Kevin Seiter** (ROSA Trust Engineering).

## Summary
- Fixes CVE-2026-45447 (Important, CVSS 8.1) in openssl-libs
- Updates ubi9/ubi-minimal base image from 9.8-1782797275 to 9.8-1784092902

## CVE Details
- **CVE:** CVE-2026-45447
- **Severity:** Important (CVSS 8.1)
- **Component:** openssl-libs
- **Description:** Vulnerability in openssl-libs requiring update to >= 1:3.5.5-4.el9_8
- **Fix:** Updated ubi9/ubi-minimal base image to 9.8-1784092902 which includes the patched openssl-libs

## Unfixable CVEs (no upstream fix available)
- **CVE-2026-58016** (Important, CVSS 7.5) in glib2 -- no fixed RPM available yet
- **CVE-2026-54369** (Important, CVSS 7.1) in libacl -- no fixed RPM available yet

## Changes
- `build/Dockerfile`: Updated FROM ubi9/ubi-minimal tag from 9.8-1782797275 to 9.8-1784092902
- `build/Dockerfile.olm-registry`: Updated FROM ubi9/ubi-minimal tag from 9.8-1782797275 to 9.8-1784092902

## Verification
- [ ] `make test` / `go build ./...` passes
- [ ] No regressions in existing functionality
- [ ] Base image update is minimal and targeted (same 9.8 stream)

## References
- Jira: [PSHP-678](https://redhat.atlassian.net/browse/PSHP-678) (parent: [PSHP-509](https://redhat.atlassian.net/browse/PSHP-509))
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-45447

---
**Project Darkstar** -- Automated CVE Remediation | Contact: Kevin Seiter (ROSA Trust Engineering)

[About Project Darkstar](https://source.redhat.com/departments/products_and_global_engineering/hybridplatforms/hybrid_platforms_blog/introducing_darkstar_an_experiment_in_ai_assisted_cve_remediation_for_rosa)

[PSHP-678]: https://redhat.atlassian.net/browse/PSHP-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ