### PR TITLE
ROSAENG-33350: Print Prow URL prominently in gangway-bridge output

### DIFF
--- a/test/e2e/gangway-bridge-template.yml
+++ b/test/e2e/gangway-bridge-template.yml
@@ -51,16 +51,18 @@ objects:
 
                   RESP=$(curl -sfSL --retry 3 --retry-delay 10 -X POST -H "Authorization: Bearer ${GANGWAY_TOKEN}" -H "Content-Type: application/json" -d "${BODY}" "${GW}/${JOB_NAME}")
                   ID=$(echo "$RESP" | jq -re .id)
+                  PROW_URL="https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${ID}"
                   log "Triggered ${JOB_NAME} -> ${ID}"
-                  log "https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${ID}"
+                  log "Prow logs: ${PROW_URL}"
 
                   END=$((SECONDS + ${TIMEOUT}))
                   while [[ $SECONDS -lt $END ]]; do
                     sleep "${POLL_INTERVAL}"
                     S=$(curl -sfSL -H "Authorization: Bearer ${GANGWAY_TOKEN}" "${GW}/${ID}" | jq -r .job_status) || S=UNKNOWN
                     log "${S} ($((SECONDS))s)"
-                    case $S in SUCCESS) exit 0;; FAILURE|ABORTED|ERROR) exit 1;; esac
+                    case $S in SUCCESS) log "Prow logs: ${PROW_URL}"; exit 0;; FAILURE|ABORTED|ERROR) log "Prow logs: ${PROW_URL}"; exit 1;; esac
                   done
+                  log "Prow logs: ${PROW_URL}"
                   log "Timeout"; exit 1
               env:
                 - name: JOB_NAME


### PR DESCRIPTION
Print the Prow job URL at trigger time and again at completion so it's immediately visible and clickable in the Grafana test logs dashboard.

Before: Prow URL was a bare log line mixed with poll output, easy to miss.
After: Prow URL printed as 'Prow logs: <url>' at the start and end of the bridge output.

Jira: https://redhat.atlassian.net/browse/ROSAENG-33350