### PR TITLE
ROSAENG-15500: Set ServiceAccountName for blackbox-exporter deployment

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,17 +1,9 @@
+version: "2"
+
 run:
-  # Our CI expects a vendor directory, hence we have to use -mod=readonly here as well.
   modules-download-mode: readonly
 
-issues:
-  # on default, golangci-lint excludes gosec. Hence, we have to
-  # explicitly disable the exclude-use-default: https://github.com/golangci/golangci-lint/issues/1504
-  exclude-use-default: false
-
-# individual linter configs go here
-linters-settings:
-
-# default linters are enabled `golangci-lint help linters`
 linters:
-  disable-all: true
+  default: none
   enable:
     - gosec

--- a/pkg/blackboxexporter/blackboxexporter.go
+++ b/pkg/blackboxexporter/blackboxexporter.go
@@ -194,6 +194,7 @@ func (b *BlackBoxExporter) templateForBlackBoxExporterDeployment(blackBoxImage s
 						Effect:   corev1.TaintEffectNoSchedule,
 						Key:      nodeLabel,
 					}},
+					ServiceAccountName: "route-monitor-operator-system",
 					Containers: []corev1.Container{{
 						Image: blackBoxImage,
 						Name:  "blackbox-exporter",

--- a/pkg/blackboxexporter/blackboxexporter_test.go
+++ b/pkg/blackboxexporter/blackboxexporter_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/openshift/route-monitor-operator/pkg/consts/blackboxexporter"
 	consterror "github.com/openshift/route-monitor-operator/pkg/consts/test/error"
 	clientmocks "github.com/openshift/route-monitor-operator/pkg/util/test/generated/mocks/client"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -511,6 +513,126 @@ var _ = Describe("Blackboxexporter", func() {
 		})
 	})
 
+})
+
+var _ = Describe("BlackBoxExporter Deployment Template", func() {
+	var (
+		mockClient *clientmocks.MockClient
+		mockCtrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = clientmocks.NewMockClient(mockCtrl)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	When("creating on a standard cluster", func() {
+		var createdDeployment *appsv1.Deployment
+
+		BeforeEach(func() {
+			createdDeployment = nil
+			infra := configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.GCPPlatformType,
+					},
+				},
+			}
+
+			gomock.InOrder(
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).SetArg(2, infra),
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(consterror.NotFoundErr),
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(consterror.NotFoundErr),
+			)
+			mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+					dep, ok := obj.(*appsv1.Deployment)
+					Expect(ok).To(BeTrue())
+					createdDeployment = dep
+					return nil
+				})
+		})
+
+		It("should set correct spec fields", func() {
+			bbe := New(mockClient, logr.Discard(), context.Background(), "test-image:latest", "test-namespace")
+			err := bbe.EnsureBlackBoxExporterDeploymentExists()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdDeployment).NotTo(BeNil())
+
+			podSpec := createdDeployment.Spec.Template.Spec
+			Expect(podSpec.ServiceAccountName).To(Equal("route-monitor-operator-system"))
+			Expect(podSpec.Containers).To(HaveLen(1))
+			Expect(podSpec.Containers[0].Name).To(Equal("blackbox-exporter"))
+			Expect(podSpec.Containers[0].Image).To(Equal("test-image:latest"))
+			Expect(podSpec.Containers[0].Ports).To(HaveLen(1))
+			Expect(podSpec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(blackboxexporter.BlackBoxExporterPortNumber)))
+			Expect(podSpec.Volumes).To(HaveLen(1))
+			Expect(podSpec.Volumes[0].Name).To(Equal("blackbox-config"))
+			Expect(podSpec.Containers[0].VolumeMounts).To(HaveLen(1))
+			Expect(podSpec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/config"))
+
+			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
+			pref := podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+			Expect(pref.Preference.MatchExpressions[0].Key).To(Equal("node-role.kubernetes.io/infra"))
+			Expect(podSpec.Tolerations[0].Key).To(Equal("node-role.kubernetes.io/infra"))
+		})
+	})
+
+	When("creating on a private NLB cluster running 4.13+", func() {
+		var createdDeployment *appsv1.Deployment
+
+		BeforeEach(func() {
+			createdDeployment = nil
+			infra := testAWSInfrastructure()
+			ic := testPrivateDefaultIC()
+			cv := configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{Name: "version"},
+				Status: configv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "4.14.5"},
+				},
+			}
+
+			gomock.InOrder(
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).SetArg(2, infra),
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).SetArg(2, ic),
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).SetArg(2, cv),
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(consterror.NotFoundErr),
+			)
+			mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+					dep, ok := obj.(*appsv1.Deployment)
+					Expect(ok).To(BeTrue())
+					createdDeployment = dep
+					return nil
+				})
+		})
+
+		It("should use master node affinity and set ServiceAccountName", func() {
+			bbe := New(mockClient, logr.Discard(), context.Background(), "test-image:latest", "test-namespace")
+			err := bbe.EnsureBlackBoxExporterDeploymentExists()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createdDeployment).NotTo(BeNil())
+
+			podSpec := createdDeployment.Spec.Template.Spec
+			Expect(podSpec.ServiceAccountName).To(Equal("route-monitor-operator-system"))
+
+			pref := podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+			Expect(pref.Preference.MatchExpressions[0].Key).To(Equal("node-role.kubernetes.io/master"))
+			Expect(podSpec.Tolerations[0].Key).To(Equal("node-role.kubernetes.io/master"))
+		})
+	})
 })
 
 func testPrivateDefaultIC() operatorv1.IngressController {

--- a/test/e2e/route_monitor_operator_tests.go
+++ b/test/e2e/route_monitor_operator_tests.go
@@ -167,6 +167,28 @@ var _ = Describe("Route Monitor Operator", Ordered, func() {
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to get console prometheusRule")
 	})
 
+	It("blackbox-exporter deployment has correct spec", func(ctx context.Context) {
+		deployment := &appsv1.Deployment{}
+		err := k8s.Get(ctx, "blackbox-exporter", namespace, deployment)
+		Expect(err).ShouldNot(HaveOccurred(), "blackbox-exporter deployment should exist")
+
+		podSpec := deployment.Spec.Template.Spec
+
+		By("checking ServiceAccountName is not defaulting to 'default'")
+		Expect(podSpec.ServiceAccountName).To(Equal("route-monitor-operator-system"),
+			"blackbox-exporter should use the operator's ServiceAccount")
+
+		By("checking container configuration")
+		Expect(podSpec.Containers).To(HaveLen(1))
+		Expect(podSpec.Containers[0].Name).To(Equal("blackbox-exporter"))
+		Expect(podSpec.Containers[0].Ports).To(HaveLen(1))
+		Expect(podSpec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(9115)))
+
+		By("checking volume configuration")
+		Expect(podSpec.Volumes).To(HaveLen(1))
+		Expect(podSpec.Volumes[0].Name).To(Equal("blackbox-config"))
+	})
+
 	It("required dependent resources are created", func(ctx context.Context) {
 		By("Creating a pod, service and route to monitor with a ServiceMonitor and PrometheusRule")
 		By("Creating the test pod")


### PR DESCRIPTION
## Summary

The blackbox-exporter Deployment created by RMO doesn't set ServiceAccountName in the PodSpec, defaulting to "default". This triggers the OCP conformance monitor test `[Monitor:no-default-service-account-operator-checker]` for pods in `openshift-route-monitor-operator` namespace.

Currently suppressed by an exception in openshift/origin (PR #31082). This PR fixes the root cause.

## Changes

- Set `ServiceAccountName` in the blackbox-exporter Deployment PodSpec to use the operator's ServiceAccount instead of defaulting to "default"
- Add unit tests verifying the deployment template spec fields (ServiceAccountName, containers, volumes, node affinity) for both standard and private NLB clusters
- Add e2e test checking the deployed blackbox-exporter Deployment spec on a live cluster
- Update `.golangci.yaml` to v2 format for local prek/golangci-lint compatibility

## Testing

- Unit tests pass (`make test`, 31 specs including 2 new)
- E2e test verifies ServiceAccountName, container config, and volumes on a real cluster
- All prek hooks pass locally
- CI will validate via conformance tests

Jira: https://redhat.atlassian.net/browse/ROSAENG-15500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Blackbox Exporter deployments now use the correct operator ServiceAccount (`route-monitor-operator-system`).
  - Deployment pod template settings are validated for both standard and private NLB cluster environments.

- **Tests**
  - Added unit coverage to verify the full Blackbox Exporter Deployment pod template (container, port, volume/mounts, service account, affinity, tolerations).
  - Added an end-to-end test to confirm the deployed Deployment spec.

- **Chores**
  - Simplified the static analysis (golangci-lint) configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->