### PR TITLE
ROSAENG-61493 Remove exclusion rules for FedRAMP from HCP and RMO config

### DIFF
--- a/hack/hypershift-package/hypershift-artifacts-template.yaml
+++ b/hack/hypershift-package/hypershift-artifacts-template.yaml
@@ -35,9 +35,6 @@ objects:
         - key: api.openshift.com/managed
           operator: In
           values: ["true"]
-        - key: api.openshift.com/fedramp
-          operator: NotIn
-          values: ["true"]
     resourceApplyMode: Sync
     resources:
     - apiVersion: policy.open-cluster-management.io/v1

--- a/hack/olm-registry/rmo-config-template.yaml
+++ b/hack/olm-registry/rmo-config-template.yaml
@@ -13,7 +13,6 @@ metadata:
 # - api.openshift.com/managed: "true"
 # - ext-hypershift.openshift.io/cluster-type: management-cluster
 # - ext-hypershift.openshift.io/cluster-sector: <sector> (matchExpressions In)
-# - api.openshift.com/fedramp: NotIn true
 #
 # For production traffic splitting in high-load regions (e.g., us-east-1 with
 # multiple RHOBS cells), see SREP-3225 for adding rhobs-cell labels to MCs.
@@ -66,10 +65,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: "true"
       matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - "true"
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Removes exclusion rules for configuration excluded from FedRAMP

### Which Jira/Github issue(s) this PR fixes?
https://redhat.atlassian.net/browse/ROSAENG-61493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed FedRAMP clusters are now included in artifact synchronization and RMO configuration selection.
  * Existing managed-cluster, sector, and management-cluster filtering remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->