### PR TITLE
ROSAENG-1331: Fix createMCStyleHCP to pass real MC CRD validation

### DIFF
--- a/test/e2e/route_monitor_operator_tests.go
+++ b/test/e2e/route_monitor_operator_tests.go
@@ -1106,11 +1106,26 @@ func createMCStyleHCP(clusterID, name, namespace string, endpointAccess hypershi
 		},
 		Spec: hypershiftv1beta1.HostedControlPlaneSpec{
 			ClusterID: clusterID,
+			InfraID:   clusterID,
 			Platform: hypershiftv1beta1.PlatformSpec{
 				Type: hypershiftv1beta1.AWSPlatform,
 				AWS: &hypershiftv1beta1.AWSPlatformSpec{
 					Region:         "us-west-2",
 					EndpointAccess: endpointAccess,
+				},
+			},
+			IssuerURL:  "https://kubernetes.default.svc",
+			PullSecret: corev1.LocalObjectReference{Name: "pull-secret"},
+			SSHKey:     corev1.LocalObjectReference{Name: "ssh-key"},
+			DNS: hypershiftv1beta1.DNSSpec{
+				BaseDomain: fmt.Sprintf("%s.test.devshift.org", name),
+			},
+			Etcd: hypershiftv1beta1.EtcdSpec{
+				ManagementType: hypershiftv1beta1.Managed,
+				Managed: &hypershiftv1beta1.ManagedEtcdSpec{
+					Storage: hypershiftv1beta1.ManagedEtcdStorageSpec{
+						Type: hypershiftv1beta1.PersistentVolumeEtcdStorage,
+					},
 				},
 			},
 			Services: []hypershiftv1beta1.ServicePublishingStrategyMapping{
@@ -1121,6 +1136,24 @@ func createMCStyleHCP(clusterID, name, namespace string, endpointAccess hypershi
 						Route: &hypershiftv1beta1.RoutePublishingStrategy{
 							Hostname: hostname,
 						},
+					},
+				},
+				{
+					Service: hypershiftv1beta1.OAuthServer,
+					ServicePublishingStrategy: hypershiftv1beta1.ServicePublishingStrategy{
+						Type: hypershiftv1beta1.Route,
+					},
+				},
+				{
+					Service: hypershiftv1beta1.Konnectivity,
+					ServicePublishingStrategy: hypershiftv1beta1.ServicePublishingStrategy{
+						Type: hypershiftv1beta1.Route,
+					},
+				},
+				{
+					Service: hypershiftv1beta1.Ignition,
+					ServicePublishingStrategy: hypershiftv1beta1.ServicePublishingStrategy{
+						Type: hypershiftv1beta1.Route,
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
- Add required HCP spec fields to the test helper so fake HCP CRs pass validation on real Management Clusters
- Fields added: etcd (Managed/PersistentVolume), issuerURL, pullSecret, sshKey, infraID, dns
- Expand services from 1 to 4 (MinItems=4 on real CRD): APIServer, OAuthServer, Konnectivity, Ignition

The existing createMCStyleHCP helper worked with the stub CRD installed on Classic STS clusters, but the real HyperShift CRD on MCs enforces validation (e.g. spec.etcd.managementType is required). This blocked the MC e2e workflow in openshift/release#82850.

Jira: https://redhat.atlassian.net/browse/ROSAENG-1331

## Test plan
- [ ] Compile succeeds with osde2e build tag
- [ ] Rehearsal of openshift/release#82850 passes with this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route monitoring test coverage by configuring all required HostedControlPlane settings.
  * Added route publishing configurations for OAuthServer, Konnectivity, and Ignition services.
  * Added managed persistent-volume-backed etcd configuration for more complete control-plane validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->