### PR TITLE
ROSAENG-1331: Increase RHOBS probe polling timeout for MC e2e

### DIFF
--- a/test/e2e/route_monitor_operator_tests.go
+++ b/test/e2e/route_monitor_operator_tests.go
@@ -596,7 +596,7 @@ var _ = Describe("RHOBS Synthetic Monitoring", Ordered, func() {
 		if testNamespace == "" {
 			testNamespace = "clusters"
 		}
-		pollingDuration = 3 * time.Minute
+		pollingDuration = 5 * time.Minute
 
 		GinkgoLogr.Info("RHOBS Synthetic Monitoring test suite initialized",
 			"environment", environment,
@@ -655,7 +655,7 @@ var _ = Describe("RHOBS Synthetic Monitoring", Ordered, func() {
 		Expect(err).ShouldNot(HaveOccurred(), "failed to update HostedControlPlane status")
 		GinkgoLogr.Info("HCP status set to Available", "clusterID", clusterID)
 
-		By("waiting for RMO to reconcile and create probe (up to 3 minutes)")
+		By("waiting for RMO to reconcile and create probe (up to 5 minutes)")
 		var probe map[string]interface{}
 		err = wait.PollUntilContextTimeout(ctx, 10*time.Second, pollingDuration, false, func(ctx context.Context) (bool, error) {
 			probes, err := listRHOBSProbes(rhobsAPIURL, fmt.Sprintf("cluster-id=%s", clusterID), oidcCredentials)
@@ -945,7 +945,6 @@ func listRHOBSProbes(baseURL, labelSelector string, creds *OIDCCredentials) ([]m
 
 	return probes, nil
 }
-
 
 // createNamespaceWithCleanup creates a namespace and registers cleanup via DeferCleanup
 func createNamespaceWithCleanup(ctx context.Context, k8s *openshift.Client, namespace string) (*corev1.Namespace, error) {
@@ -1403,7 +1402,6 @@ func getOIDCCredentialsFromConfigMap(ctx context.Context, k8s *openshift.Client)
 		ProbeAPIURL:  probeAPIURL,
 	}, nil
 }
-
 
 func getOIDCCredentials(ctx context.Context, environment string) (*OIDCCredentials, error) {
 	// Read credentials from environment variables (must match rmo_secret.yml for CI/CD compatibility)


### PR DESCRIPTION
## Summary
- Increase pollingDuration from 3m to 5m in RHOBS Synthetic Monitoring tests
- On real MCs, the reconciliation pipeline (OIDC token exchange + RHOBS API) can exceed 3 minutes
- Matches the controller's own rhobsAPIRetryTimeout (5m)

Unblocks the MC e2e workflow rehearsal in openshift/release#82850, where probe creation timed out at 3m.

Jira: https://redhat.atlassian.net/browse/ROSAENG-1331

## Test plan
- [ ] Compile succeeds with osde2e build tag
- [ ] Rehearsal of openshift/release#82850 passes with this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the RHOBS synthetic monitoring test timeout from 3 to 5 minutes.
  * Updated the public HCP probe test message to reflect the new timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->