### PR TITLE
ROSAENG-1331: Fix HCP status update to use status subresource

### DIFF
--- a/test/e2e/route_monitor_operator_tests.go
+++ b/test/e2e/route_monitor_operator_tests.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -946,7 +948,6 @@ func listRHOBSProbes(baseURL, labelSelector string, creds *OIDCCredentials) ([]m
 	return probes, nil
 }
 
-
 // createNamespaceWithCleanup creates a namespace and registers cleanup via DeferCleanup
 func createNamespaceWithCleanup(ctx context.Context, k8s *openshift.Client, namespace string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{
@@ -1029,10 +1030,17 @@ func setHostedControlPlaneAvailable(ctx context.Context, k8s *openshift.Client, 
 	// RMO only processes HCPs with Available=true status
 	// Use retry loop with optimistic concurrency control
 
-	// Retry up to 5 times if we get "object has been modified" errors
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get REST config: %w", err)
+	}
+	statusClient, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to create status client: %w", err)
+	}
+
 	maxRetries := 5
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		// Fetch the latest version
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(hypershiftv1beta1.GroupVersion.WithKind("HostedControlPlane"))
 		err := k8s.Get(ctx, hcp.Name, hcp.Namespace, u)
@@ -1040,7 +1048,6 @@ func setHostedControlPlaneAvailable(ctx context.Context, k8s *openshift.Client, 
 			return fmt.Errorf("failed to fetch HCP: %w", err)
 		}
 
-		// Update the status field
 		now := metav1.Now()
 		conditions := []interface{}{
 			map[string]interface{}{
@@ -1059,10 +1066,8 @@ func setHostedControlPlaneAvailable(ctx context.Context, k8s *openshift.Client, 
 			return fmt.Errorf("failed to set status field: %w", err)
 		}
 
-		// Try to update
-		err = k8s.Update(ctx, u)
+		err = statusClient.Status().Update(ctx, u)
 		if err == nil {
-			// Success!
 			return nil
 		}
 
@@ -1403,7 +1408,6 @@ func getOIDCCredentialsFromConfigMap(ctx context.Context, k8s *openshift.Client)
 		ProbeAPIURL:  probeAPIURL,
 	}, nil
 }
-
 
 func getOIDCCredentials(ctx context.Context, environment string) (*OIDCCredentials, error) {
 	// Read credentials from environment variables (must match rmo_secret.yml for CI/CD compatibility)


### PR DESCRIPTION
## Summary
- Use `client.Status().Update()` instead of `client.Update()` for setting HCP Available condition
- On real MCs, the HCP CRD has status as a subresource. Regular `Update()` silently ignores status changes, so the Available condition was never set
- RMO logged `HCP not yet Available, delaying probe deployment` and never created a probe
- Also works on Classic STS clusters since the stub CRD defines `subresources.status`

Root cause of the MC e2e rehearsal failure on openshift/release#82850. RMO was reconciling the fake HCP but skipping probe creation because it couldn't see the Available condition.

Jira: https://redhat.atlassian.net/browse/ROSAENG-1331

## Test plan
- [ ] go test -tags osde2e -c compiles
- [ ] Rehearsal of openshift/release#82850 passes (probe creation succeeds on real MC)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end route monitoring test reliability by ensuring HostedControlPlane availability updates are applied through the appropriate status mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->