### PR TITLE
ROSAENG-1331: Fix MC e2e test to match HCP by OCM label

### DIFF
--- a/test/e2e/mc_probe_verification_test.go
+++ b/test/e2e/mc_probe_verification_test.go
@@ -91,12 +91,14 @@ var _ = Describe("MC Probe Verification", Ordered, func() {
 
 		var found bool
 		for _, hcp := range hcpList.Items {
-			if hcp.Spec.ClusterID == clusterID {
+			labelID := hcp.Labels["api.openshift.com/id"]
+			if labelID == clusterID || hcp.Spec.ClusterID == clusterID {
 				found = true
 				logFields := []interface{}{
 					"name", hcp.Name,
 					"namespace", hcp.Namespace,
-					"clusterID", hcp.Spec.ClusterID,
+					"specClusterID", hcp.Spec.ClusterID,
+					"labelID", labelID,
 					"platform", hcp.Spec.Platform.Type,
 				}
 				if hcp.Spec.Platform.AWS != nil {


### PR DESCRIPTION
## Summary
- Fix HCP matching in MC Probe Verification test to use `api.openshift.com/id` label in addition to `Spec.ClusterID`
- The `cluster-id` from SHARED_DIR is the OCM internal ID (e.g. `2s404idb...`), which maps to the HCP's label, not `Spec.ClusterID` (which is a UUID)
- This caused the test to fail with "HCP not found on MC" even though the HCP was provisioned

Jira: https://redhat.atlassian.net/browse/ROSAENG-1331

## Test plan
- [ ] Compile succeeds
- [ ] Rehearsal of openshift/release#83214 passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HCP discovery by matching clusters using either supported cluster identifier.
  * Enhanced diagnostic logging to report both available cluster identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->