### PR TITLE
ROSAENG-1331: Add configurable reconcile-interval for MC e2e testing

### DIFF
--- a/controllers/hostedcontrolplane/hostedcontrolplane.go
+++ b/controllers/hostedcontrolplane/hostedcontrolplane.go
@@ -143,6 +143,11 @@ func (r *HostedControlPlaneReconciler) getRHOBSConfig(ctx context.Context) (RHOB
 	if strings.TrimSpace(configMap.Data["skip-infrastructure-health-check"]) == "true" {
 		cfg.SkipInfrastructureHealthCheck = true
 	}
+	if v := strings.TrimSpace(configMap.Data["reconcile-interval"]); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d >= 10*time.Second {
+			cfg.ReconcileInterval = d
+		}
+	}
 
 	// Read Dynatrace configuration - defaults to disabled
 	dynatraceConfig := DynatraceConfig{Enabled: false}
@@ -375,7 +380,11 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Requeue periodically to ensure probes stay in sync for HCPs that existed
 	// before RMO was configured. The ensureRHOBSProbe call is idempotent (heartbeat
 	// update if probe exists, create if not).
-	return ctrl.Result{RequeueAfter: periodicReconcileInterval}, err
+	interval := periodicReconcileInterval
+	if rhobsConfig.ReconcileInterval > 0 {
+		interval = rhobsConfig.ReconcileInterval
+	}
+	return ctrl.Result{RequeueAfter: interval}, err
 }
 
 // getKubeAPIServerPort resolves the kube-apiserver Service port. Used by both the

--- a/controllers/hostedcontrolplane/synthetics.go
+++ b/controllers/hostedcontrolplane/synthetics.go
@@ -262,6 +262,7 @@ type RHOBSConfig struct {
 	OIDCIssuerURL                 string
 	OnlyPublicClusters            bool
 	SkipInfrastructureHealthCheck bool
+	ReconcileInterval             time.Duration
 }
 
 // DynatraceConfig holds Dynatrace feature flag configuration.


### PR DESCRIPTION
## Summary
- Add `reconcile-interval` field to the `route-monitor-operator-config` ConfigMap
- When set (e.g. `reconcile-interval: 30s`), overrides the default 10-minute periodic reconcile interval
- The MC e2e setup step sets this to 30s so RMO processes freshly provisioned HCPs within seconds instead of waiting up to 10 min for the periodic cycle
- Probe timeout stays at 10 min (health checks still need time, but reconciliation is much faster)

This avoids 20+ minute waits in presubmit jobs while keeping the full health check pipeline intact.

Jira: https://redhat.atlassian.net/browse/ROSAENG-1331

## Test plan
- [ ] `go build ./...` passes
- [ ] Rehearsal of openshift/release#83214 passes with setup step setting `reconcile-interval: 30s`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the hosted control plane reconciliation interval through operator configuration.
  * Valid intervals of at least 10 seconds now control how often periodic reconciliation runs.

* **Bug Fixes**
  * Invalid, empty, or shorter interval settings are ignored and safely retain the existing default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->