### PR TITLE
ROSAENG-1331: Increase MC e2e probe timeout to 20 minutes

### DIFF
--- a/test/e2e/mc_probe_verification_test.go
+++ b/test/e2e/mc_probe_verification_test.go
@@ -31,7 +31,7 @@ var _ = Describe("MC Probe Verification", Ordered, func() {
 
 	const (
 		rmoNamespace = "openshift-route-monitor-operator"
-		probeTimeout = 10 * time.Minute
+		probeTimeout = 20 * time.Minute
 	)
 
 	BeforeAll(func(ctx context.Context) {


### PR DESCRIPTION
## Summary
- Increase probeTimeout from 10 to 20 minutes
- HCP Available condition on rosa-e2e sector takes >10 min after provisioning
- The 30s reconcile-interval works but the HCP itself needs more time

Jira: https://redhat.atlassian.net/browse/ROSAENG-1331

## Test plan
- [x] Compile succeeds
- [ ] Rehearsal of openshift/release#83214 passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the maximum wait time for MC probe verification from 10 to 20 minutes, improving reliability for slower test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->