### PR TITLE
Update blackbox-exporter image

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,7 +58,7 @@ spec:
             - name: BLACKBOX_IMAGE
               # override so you can pull any blackbox-exporter image you fancy
               # this value is the default value
-              value: "quay.io/prometheus/blackbox-exporter@sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e"
+              value: "quay.io/prometheus/blackbox-exporter@sha256:bedbb156b4e5e85103fdc32e90177513a2f6e2069e04945cea0184b911dd5a99"
             - name: BLACKBOX_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/route-monitor-operator-controller-manager.Deployment.yaml
+++ b/deploy/route-monitor-operator-controller-manager.Deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: LOG_LEVEL
               value: "1"
             - name: BLACKBOX_IMAGE
-              value: quay.io/prometheus/blackbox-exporter@sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e
+              value: quay.io/prometheus/blackbox-exporter@sha256:bedbb156b4e5e85103fdc32e90177513a2f6e2069e04945cea0184b911dd5a99
             - name: BLACKBOX_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy_pko/Deployment-route-monitor-operator-controller-manager.yaml.gotmpl
+++ b/deploy_pko/Deployment-route-monitor-operator-controller-manager.yaml.gotmpl
@@ -52,7 +52,7 @@ spec:
         - name: LOG_LEVEL
           value: '1'
         - name: BLACKBOX_IMAGE
-          value: quay.io/prometheus/blackbox-exporter@sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e
+          value: quay.io/prometheus/blackbox-exporter@sha256:bedbb156b4e5e85103fdc32e90177513a2f6e2069e04945cea0184b911dd5a99
         - name: BLACKBOX_NAMESPACE
           valueFrom:
             fieldRef:

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func main() {
 	var onlyPublicClusters bool
 	var skipInfrastructureHealthCheck bool
 
-	flag.StringVar(&blackboxExporterImage, "blackbox-image", "quay.io/prometheus/blackbox-exporter@sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e", "The image that will be used for the blackbox-exporter deployment")
+	flag.StringVar(&blackboxExporterImage, "blackbox-image", "quay.io/prometheus/blackbox-exporter@sha256:bedbb156b4e5e85103fdc32e90177513a2f6e2069e04945cea0184b911dd5a99", "The image that will be used for the blackbox-exporter deployment")
 	flag.StringVar(&blackboxExporterNamespace, "blackbox-namespace", config.OperatorNamespace, "Blackbox-exporter deployment will reside on this Namespace")
 	flag.StringVar(&probeAPIURL, "probe-api-url", "", "The fully qualified API URL for RHOBS synthetics probe management (for HostedCluster monitoring). When empty, uses default blackbox exporter behavior.")
 	flag.StringVar(&probeTenant, "probe-tenant", "hcp", "RHOBS tenant name used in API URLs. Defaults to 'hcp'.")


### PR DESCRIPTION
## Summary

- Updates the pinned `blackbox-exporter` image to the latest upstream build (2026-09-08)
- Part of https://redhat.atlassian.net/browse/ROSAENG-66305 ticket

## Test plan

- [ ] CI passes
- [ ] blackbox-exporter pods come up healthy on a test cluster
- [ ] Route probing and SLO alerting still function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the bundled Blackbox Exporter container image to a new pinned image digest.
  - Applied the updated image consistently across the controller’s default settings and deployment configurations.
  - This keeps monitoring deployments aligned while preserving reproducible image selection across supported installation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Tested on GCP INT cluster 2sjofn1q8d18mcnfpa8ep23vqgmq2g8n (gcp-lease-int-01). The new blackbox-exporter image was patched directly onto the deployment and confirmed healthy:
 - Pod came up healthy (1/1 Running)
 - /-/healthy returned 200 OK

Build info confirmed: goversion="go1.26.8", version="0.28.0" — covers all required stdlib patches